### PR TITLE
Fix bars

### DIFF
--- a/visualizer.js
+++ b/visualizer.js
@@ -74,7 +74,10 @@ Visualizer = {
             this.bufferLength = this.analyser.fftSize;
             this.dataArray = new Uint8Array(this.bufferLength);
         } else if(this.style == this.BAR) {
-            this.analyser.fftSize = 64; // Must be a power of two
+            this.analyser.fftSize = 2048; // Must be a power of two
+            this.analyser.smoothingTimeConstant=0.9;
+            this.analyser.maxDecibels=-50;
+            this.analyser.minDecibels=-75;
             // Number of bins/bars we get
             this.bufferLength = this.analyser.frequencyBinCount;
             this.dataArray = new Uint8Array(this.bufferLength);
@@ -150,13 +153,17 @@ Visualizer = {
                 // Draw the gray peak line
                 this.canvasCtx.drawImage(this.barCanvas, 0, 0, 6, 2, x, y - 2, 6, 2);
                 // Draw the gradient
+                // ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
                 this.canvasCtx.drawImage(this.barCanvas, 0, y, 6, height, x, y, 6, height);
             }
         }.bind(this);
 
         this.analyser.getByteFrequencyData(this.dataArray);
-        for(j = 0; j < this.bufferLength; j++) {
-            height = this.dataArray[j] * (15/256);
+        var barCount=19; // How many bars to display
+        var spread=(this.bufferLength-250)/(barCount-1);
+        for(j = 0; j < barCount; j++) {
+            // console.debug(Math.ceil(spread*j),this.bufferLength); // just checking the spread
+            height = this.dataArray[Math.ceil(spread*j)] * (15/256);
             printBar(j*8, height);
         }
     }


### PR DESCRIPTION
Increasing the fft size makes a big difference.
Each element in the buffer represents a frequency range and its amplitude.
By increasing the fft size you increase the distance in frequency between each bar (as were only painting 19 out of woteva) and makes the visual jump around alot more as each frequency isnt so close to each other theres more variance.

Im sooooo tempted to knock off the higher range frequencies as their hardly ever drawn (actually, I ended up doing that).
Try it....
Change this line....
`var pos=this.bufferLength/(barCount-1);`
...too....
`var pos=(this.bufferLength-250)/(barCount-1); // this one with an fft.size of 2048 (buffer 1024) seems to look good on a bunch of stuff I tried with most half amp and one full amp.`
Your going to be missing the higher frequencies but who really cares.  Were just giving them something pretty to look at, not trying to do any scientific analysis. ;)

Then try playing with the...
minDecibels
maxDecibels
smoothingTimeConstant
Ive set them to something that jumps around alot coz I like it like that, but the first bar is up to high alot of the time...still, its something to look at ;)
Just play with them till you get something YOU like :P
