### PR TITLE
Enable Milkdrop behind a feature flag

### DIFF
--- a/js/components/MilkdropWindow/index.js
+++ b/js/components/MilkdropWindow/index.js
@@ -5,9 +5,6 @@ const PRESET_TRANSITION_SECONDS = 2.7;
 const MILLISECONDS_BETWEEN_PRESET_TRANSITIONS = 15000;
 
 class MilkdropWindow extends React.Component {
-  constructor() {
-    super();
-  }
   componentDidMount() {
     require.ensure(
       [

--- a/js/components/MilkdropWindow/index.js
+++ b/js/components/MilkdropWindow/index.js
@@ -3,6 +3,9 @@ import screenfull from "screenfull";
 import butterchurn from "butterchurn";
 import reactionDiffusion2 from "butterchurn-presets/presets/converted/Geiss - Reaction Diffusion 2";
 
+const PRESET_TRANSITION_SECONDS = 2.7;
+const MILLISECONDS_BETWEEN_PRESET_TRANSITIONS = 15000;
+
 class MilkdropWindow extends React.Component {
   constructor() {
     super();
@@ -29,8 +32,8 @@ class MilkdropWindow extends React.Component {
       this.cycleInterval = setInterval(() => {
         const presetIdx = Math.floor(presetKeys.length * Math.random());
         const preset = presets[presetKeys[presetIdx]];
-        this.visualizer.loadPreset(preset, 2.7);
-      }, 15000);
+        this.visualizer.loadPreset(preset, PRESET_TRANSITION_SECONDS);
+      }, MILLISECONDS_BETWEEN_PRESET_TRANSITIONS);
     });
   }
   componentWillUnmount() {

--- a/js/config.js
+++ b/js/config.js
@@ -34,4 +34,5 @@ export const initialTracks = config.initialTracks || [
 
 export const hideAbout = config.hideAbout || false;
 export const initialState = config.initialState || undefined;
+export const milkdrop = config.milkdrop || false;
 export const sentryDsn = SENTRY_DSN;

--- a/js/index.js
+++ b/js/index.js
@@ -8,7 +8,7 @@ import visor from "../skins/Vizor1-01.wsz";
 import xmms from "../skins/XMMS-Turquoise.wsz";
 import zaxon from "../skins/ZaxonRemake1-0.wsz";
 import green from "../skins/Green-Dimension-V2.wsz";
-// import MilkdropWindow from "./components/MilkdropWindow";
+import MilkdropWindow from "./components/MilkdropWindow";
 import Webamp from "./webamp";
 import {
   STEP_MARQUEE,
@@ -25,7 +25,8 @@ import {
   skinUrl,
   initialTracks,
   initialState,
-  sentryDsn
+  sentryDsn,
+  milkdrop
 } from "./config";
 
 const NOISY_ACTION_TYPES = new Set([
@@ -110,6 +111,10 @@ Raven.context(() => {
     document.getElementById("app").style.visibility = "hidden";
     return;
   }
+  const __extraWindows = [];
+  if (milkdrop) {
+    __extraWindows.push({ title: "Milkdrop 2", Component: MilkdropWindow });
+  }
 
   const webamp = new Webamp({
     initialSkin: {
@@ -139,12 +144,7 @@ Raven.context(() => {
       }
     ],
     enableHotkeys: true,
-    // __extraWindows: [
-    //   {
-    //     title: "Milkdrop 2",
-    //     Component: MilkdropWindow
-    //   }
-    // ],
+    __extraWindows,
     __initialState: initialState,
     __customMiddlewares: [analyticsMiddleware, ravenMiddleware]
   });


### PR DESCRIPTION
This will allow us to ship the Milkdrop window to "production" (https://webamp.org) behind a "feature flag".

Adding `#{"milkdrop":true}` to the the end of the URL will enable the window in it's current form.

This will let us ensure that we know it's working in production and to test the load speed from our actual CDN.

Review @jberg 