### PR TITLE
load smaller preset pack and randomize initial preset

### DIFF
--- a/js/components/MilkdropWindow/PresetOverlay.js
+++ b/js/components/MilkdropWindow/PresetOverlay.js
@@ -28,7 +28,7 @@ class PresetOverlay extends React.Component {
         this.setState({
           presetIdx: Math.min(
             this.state.presetIdx + 1,
-            Object.keys(this.props.presets).length - 1
+            this.props.presetKeys.length - 1
           )
         });
         e.stopPropagation();
@@ -44,7 +44,7 @@ class PresetOverlay extends React.Component {
     }
   }
   render() {
-    if (!this.props.presets) {
+    if (!this.props.presetKeys) {
       return (
         <div
           style={{
@@ -61,8 +61,7 @@ class PresetOverlay extends React.Component {
     }
 
     // display highlighted preset in the middle if possible
-    const presetKeys = Object.keys(this.props.presets);
-    const numPresets = presetKeys.length;
+    const numPresets = this.props.presetKeys.length;
     let presetListLen = Math.floor(this.props.height / 20);
     presetListLen = Math.min(Math.max(presetListLen, 3), numPresets);
     presetListLen = presetListLen % 2 ? presetListLen : presetListLen - 1;
@@ -73,7 +72,7 @@ class PresetOverlay extends React.Component {
       startIdx = Math.max(endIdx - presetListLen, 0);
       endIdx = Math.min(startIdx + presetListLen, numPresets);
     }
-    const presets = presetKeys.slice(startIdx, endIdx);
+    const presets = this.props.presetKeys.slice(startIdx, endIdx);
     const presetElms = presets.map((presetName, i) => {
       let color;
       if (i + startIdx === this.props.currentPreset) {

--- a/js/components/MilkdropWindow/index.js
+++ b/js/components/MilkdropWindow/index.js
@@ -164,13 +164,10 @@ class MilkdropWindow extends React.Component {
   }
   async _loadMainPresetPack() {
     return require.ensure(
-      ["butterchurn-presets"],
+      ["butterchurn-presets/lib/butterchurnPresetsNonMinimal.min"],
       require => {
-        const butterchurnPresets = require("butterchurn-presets");
-        this.presets = Object.assign(
-          this.presets,
-          butterchurnPresets.getPresets()
-        );
+        const butterchurnNonMinimalPresets = require("butterchurn-presets/lib/butterchurnPresetsNonMinimal.min");
+        Object.assign(this.presets, butterchurnNonMinimalPresets.getPresets());
       },
       e => {
         console.error("Error loading Butterchurn Presets", e);

--- a/js/components/MilkdropWindow/index.js
+++ b/js/components/MilkdropWindow/index.js
@@ -22,14 +22,14 @@ class MilkdropWindow extends React.Component {
   }
   componentDidMount() {
     require.ensure(
-      [
-        "butterchurn",
-        "butterchurn-presets/presets/converted/Geiss - Reaction Diffusion 2.json"
-      ],
+      ["butterchurn", "butterchurn-presets/lib/butterchurnPresetsMinimal.min"],
       require => {
         const analyserNode = this.props.analyser;
         const butterchurn = require("butterchurn");
-        const reactionDiffusion2 = require("butterchurn-presets/presets/converted/Geiss - Reaction Diffusion 2.json");
+        const butterchurnPresets = require("butterchurn-presets/lib/butterchurnPresetsMinimal.min");
+        this.presets = butterchurnPresets.getPresets();
+        this.presetKeys = Object.keys(this.presets);
+        const presetIdx = Math.floor(Math.random() * this.presetKeys.length);
 
         this.visualizer = butterchurn.createVisualizer(
           analyserNode.context,
@@ -43,7 +43,7 @@ class MilkdropWindow extends React.Component {
         this._canvasNode.width = this.props.width;
         this._canvasNode.height = this.props.height;
         this.visualizer.connectAudio(analyserNode);
-        this.visualizer.loadPreset(reactionDiffusion2, 0);
+        this.visualizer.loadPreset(this.presets[this.presetKeys[presetIdx]], 0);
         // Kick off the animation loop
         const loop = () => {
           if (this.props.status === "PLAYING") {
@@ -53,21 +53,7 @@ class MilkdropWindow extends React.Component {
         };
         loop();
 
-        screenfull.onchange(this._handleFullscreenChange);
-      },
-      e => {
-        console.error("Error loading Butterchurn", e);
-      },
-      "butterchurn"
-    );
-
-    require.ensure(
-      ["butterchurn-presets"],
-      require => {
-        const butterchurnPresets = require("butterchurn-presets");
-        this.presets = butterchurnPresets.getPresets();
-        this.presetKeys = Object.keys(this.presets);
-        this.presetHistory = [];
+        this.presetHistory = [presetIdx];
         this.presetRandomize = true;
         this.presetCycle = true;
         this._restartCycling();
@@ -76,9 +62,9 @@ class MilkdropWindow extends React.Component {
         );
       },
       e => {
-        console.error("Error loading Butterchurn presets", e);
+        console.error("Error loading Butterchurn", e);
       },
-      "butterchurn-presets"
+      "butterchurn"
     );
   }
   componentWillUnmount() {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "butterchurn": "^2.4.3",
-    "butterchurn-presets": "^2.4.4",
+    "butterchurn-presets": "^2.4.5",
     "canvas-mock": "0.0.0",
     "cardinal-spline-js": "^2.3.6",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "butterchurn": "^2.4.3",
-    "butterchurn-presets": "^2.4.5",
+    "butterchurn-presets": "^2.4.7",
     "canvas-mock": "0.0.0",
     "cardinal-spline-js": "^2.3.6",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "butterchurn": "^2.4.3",
-    "butterchurn-presets": "^2.4.1",
+    "butterchurn-presets": "^2.4.4",
     "canvas-mock": "0.0.0",
     "cardinal-spline-js": "^2.3.6",
     "classnames": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,9 +1269,9 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-butterchurn-presets@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-2.4.4.tgz#23764b47e9d30c29caf95d974a92002f6f29c057"
+butterchurn-presets@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-2.4.5.tgz#5e05f2c57e941ff2d24f655b0ea842ca1ff4787a"
   dependencies:
     babel-runtime "^6.26.0"
     ecma-proposal-math-extensions "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,9 +1269,9 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-butterchurn-presets@^2.4.5:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-2.4.5.tgz#5e05f2c57e941ff2d24f655b0ea842ca1ff4787a"
+butterchurn-presets@^2.4.7:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-2.4.7.tgz#41e4e37cd3af2aec124fa8062352816100956c29"
   dependencies:
     babel-runtime "^6.26.0"
     ecma-proposal-math-extensions "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,9 +1269,9 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-butterchurn-presets@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-2.4.1.tgz#cad3e94bf5665d65610bf336b57623616726bbe8"
+butterchurn-presets@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-2.4.4.tgz#23764b47e9d30c29caf95d974a92002f6f29c057"
   dependencies:
     babel-runtime "^6.26.0"
     ecma-proposal-math-extensions "0.0.2"


### PR DESCRIPTION
Currently we are loading 2 chunks in parallel:
butterchurn: 191k
presets: 654k

I packaged up a smaller preset pack and now we load them together
butterchurn + minimal pack: 380k

I think this is small enough that we can load them all instead of 1 preset to start now?  I can shrink it a bit more if we want.

Also, I'm still a fan of more presets being better :D I figure we can either (or both)
- load presets in the background after 5-10 have been seen
- allow loading other preset packs from the preset selection overlay