### PR TITLE
New layout

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -120,10 +120,10 @@ Raven.context(() => {
       Component: MilkdropWindow
     });
     __initialWindowLayout = {
-      equalizer: { position: { x: 0, y: 116 } },
       main: { position: { x: 0, y: 0 } },
-      playlist: { position: { x: 275, y: 0 }, size: [0, 8] },
-      milkdrop: { position: { x: 0, y: 232 } }
+      equalizer: { position: { x: 0, y: 116 } },
+      playlist: { position: { x: 0, y: 232 }, size: [0, 4] },
+      milkdrop: { position: { x: 275, y: 0 }, size: [7, 12] }
     };
 
     document.getElementById("butterchurn-share").style.display = "flex";


### PR DESCRIPTION
Trying out a new layout for when Milkdrop is enabled. Feedback welcome.

**[Try it out](https://deploy-preview-597--ecstatic-poincare-fe4c13.netlify.com/#{%22milkdrop%22:true})**

<img width="1028" alt="screen shot 2018-06-11 at 9 35 48 pm" src="https://user-images.githubusercontent.com/162735/41270338-78f8ac2a-6dbf-11e8-965e-eaca66212eb9.png">
