### PR TITLE
resolved file picker console error

### DIFF
--- a/js/fileUtils.js
+++ b/js/fileUtils.js
@@ -76,7 +76,7 @@ export async function genArrayBufferFromFileReference(fileReference) {
 export async function promptForFileReferences({
   accept = null,
   directory = false
-}) {
+} = {}) {
   return new Promise(resolve => {
     // Does this represent a memory leak somehow?
     // Can this fail? Do we ever reject?


### PR DESCRIPTION
Resolves console error: `Uncaught (in promise) TypeError: Cannot destructure property 'accept' of 'undefined' or 'null'.` when trying to pick an individual file.