### PR TITLE
fix oscilloscope amplitude and direction

### DIFF
--- a/js/components/Visualizer.js
+++ b/js/components/Visualizer.js
@@ -226,8 +226,8 @@ class Visualizer extends React.Component {
     // Iterate over the width of the canvas in "real" pixels.
     for (let j = 0; j <= this._renderWidth(); j++) {
       const amplitude = sliceAverage(this.dataArray, sliceWidth, j);
-      const percentAmplitude = (amplitude - 128) / 128; // dataArray gives us bytes
-      const y = percentAmplitude * h + h / 2; // center wave at half height
+      const percentAmplitude = amplitude / 255; // dataArray gives us bytes
+      const y = (1 - percentAmplitude) * h; // flip y
       const x = j * PIXEL_DENSITY;
 
       // Canvas coordinates are in the middle of the pixel by default.


### PR DESCRIPTION
@The1Freeman pointed out that the oscilloscope was getting cutoff, and I checked and my math for the calculation was wrong.  This basically reverts to the previous way of calculating, but also flips the y, because I noticed that was wrong: currently if you max the amplitude out it draws a line on the bottom of the visualizer area.