### PR TITLE
Optimize painting

### DIFF
--- a/js/components/MainWindow/Marquee.js
+++ b/js/components/MainWindow/Marquee.js
@@ -118,7 +118,8 @@ class Marquee extends React.Component {
     const offsetPixels = pixelUnits(-offset);
     const style = {
       whiteSpace: "nowrap",
-      willChange: "transform"
+      willChange: "transform",
+      transform: `translateX(${offsetPixels})`
     };
     return (
       <div
@@ -127,7 +128,7 @@ class Marquee extends React.Component {
         onMouseDown={this.handleMouseDown}
         title="Song Title"
       >
-        <div style={{ ...style, transform: `translateX(${offsetPixels})` }}>
+        <div style={{ style }}>
           <CharacterString>{loopText(text)}</CharacterString>
         </div>
       </div>

--- a/js/components/MainWindow/Marquee.js
+++ b/js/components/MainWindow/Marquee.js
@@ -128,7 +128,7 @@ class Marquee extends React.Component {
         onMouseDown={this.handleMouseDown}
         title="Song Title"
       >
-        <div style={{ style }}>
+        <div style={style}>
           <CharacterString>{loopText(text)}</CharacterString>
         </div>
       </div>

--- a/js/components/MainWindow/Marquee.js
+++ b/js/components/MainWindow/Marquee.js
@@ -115,7 +115,11 @@ class Marquee extends React.Component {
   render() {
     const { text, marqueeStep } = this.props;
     const offset = stepOffset(text, marqueeStep, this.state.dragOffset);
-    const marginLeft = pixelUnits(-offset);
+    const offsetPixels = pixelUnits(-offset);
+    const style = {
+      whiteSpace: "nowrap",
+      willChange: "transform"
+    };
     return (
       <div
         id="marquee"
@@ -123,7 +127,7 @@ class Marquee extends React.Component {
         onMouseDown={this.handleMouseDown}
         title="Song Title"
       >
-        <div style={{ marginLeft }}>
+        <div style={{ ...style, transform: `translateX(${offsetPixels})` }}>
           <CharacterString>{loopText(text)}</CharacterString>
         </div>
       </div>

--- a/js/components/MainWindow/__snapshots__/index.test.js.snap
+++ b/js/components/MainWindow/__snapshots__/index.test.js.snap
@@ -139,7 +139,9 @@ exports[`MainWindow renders to snapshot 1`] = `
       <div
         style={
           Object {
-            "marginLeft": "0px",
+            "transform": "translateX(0px)",
+            "whiteSpace": "nowrap",
+            "willChange": "transform",
           }
         }
       >

--- a/js/components/WindowManager.js
+++ b/js/components/WindowManager.js
@@ -183,7 +183,9 @@ class WindowManager extends React.Component {
 
   render() {
     const style = {
-      position: "absolute"
+      position: "absolute",
+      top: 0,
+      left: 0
     };
 
     const parentStyle = {
@@ -198,7 +200,7 @@ class WindowManager extends React.Component {
         {this.props.windowsInfo.map(w => (
           <div
             onMouseDown={e => this.handleMouseDown(w.key, e)}
-            style={{ ...style, left: w.x, top: w.y }}
+            style={{ ...style, transform: `translate(${w.x}px, ${w.y}px)` }}
             key={w.key}
           >
             {this.props.windows[w.key]}


### PR DESCRIPTION
Windows repositioning doesn't trigger layout recalculation and painting.

Marquee is forced to be on its own layer and doesn't cause the main window to repaint - only composition is done (on the GPU).