### PR TITLE
Fix add file button handler

### DIFF
--- a/js/fileUtils.ts
+++ b/js/fileUtils.ts
@@ -94,7 +94,7 @@ interface PromptForFileReferenceOptions {
 
 export async function promptForFileReferences(
   { accept, directory = false }: PromptForFileReferenceOptions = {
-    accept,
+    accept: null,
     directory: false
   }
 ): Promise<FileList> {


### PR DESCRIPTION
Adding new file via Add File button is currently broken.

The reason is `accept` won't be defined when using the default handler parameters.