### PR TITLE
Type WebampLazy

### DIFF
--- a/config/webpack.library.js
+++ b/config/webpack.library.js
@@ -69,8 +69,8 @@ module.exports = {
   entry: {
     bundle: "./js/webamp.js",
     "bundle.min": "./js/webamp.js",
-    "lazy-bundle": "./js/webampLazy.js",
-    "lazy-bundle.min": "./js/webampLazy.js"
+    "lazy-bundle": "./js/webampLazy.tsx",
+    "lazy-bundle.min": "./js/webampLazy.tsx"
   },
   output: {
     path: path.resolve(__dirname, "../built"),


### PR DESCRIPTION
The goal would be to have index.d.ts use this instead of what is has today. The problem is that there are some private options that webamp can accept which I would rather not have as part of the public interface. Is there some way to define a class interface which WebampLazy can `implement` and still allow the actual implementation to have additional options?