### PR TITLE
Butterchurn dont error out on non milk/json file in directory when lo…

### DIFF
--- a/js/actionCreators/milkdrop.ts
+++ b/js/actionCreators/milkdrop.ts
@@ -103,7 +103,7 @@ export function appendPresetFileList(fileList: FileList): Dispatchable {
             }
           } as StatePreset;
         } else {
-          throw new Error("Invalid type");
+          console.error("Invalid type preset when loading directory");
         }
         return null as never;
       })


### PR DESCRIPTION
…ading

We could check to make sure there is at least one .json or .milk file in the directory and throw an alert in that case, but seemed a bit overkill.