### PR TITLE
Inject media class

### DIFF
--- a/js/media/index.ts
+++ b/js/media/index.ts
@@ -12,6 +12,9 @@ interface StereoBalanceNodeType extends AudioNode {
   };
 }
 
+// NOTE: While this is not technically a public API, https://winampify.io/ is
+// replacing this class with a custom version. Breaking changes to this API
+// surface should be communicated to Remi.
 export default class Media {
   _emitter: Emitter;
   _context: AudioContext;

--- a/js/webampLazy.tsx
+++ b/js/webampLazy.tsx
@@ -125,6 +125,7 @@ interface PrivateOptions {
     };
   };
   __butterchurnOptions: ButterchurnOptions;
+  // This is used by https://winampify.io/ to proxy through to Spotify's API.
   __customMediaClass: typeof Media; // This should have the same interface as Media
 }
 

--- a/js/webampLazy.tsx
+++ b/js/webampLazy.tsx
@@ -125,6 +125,7 @@ interface PrivateOptions {
     };
   };
   __butterchurnOptions: ButterchurnOptions;
+  __customMediaClass: typeof Media; // This should have the same interface as Media
 }
 
 // Return a promise that resolves when the store matches a predicate.
@@ -180,6 +181,7 @@ class Winamp {
       requireMusicMetadata,
       handleTrackDropEvent,
       __butterchurnOptions,
+      __customMediaClass,
     } = this.options;
 
     // TODO: Make this much cleaner
@@ -203,7 +205,7 @@ class Winamp {
 
     // TODO: Validate required options
 
-    this.media = new Media();
+    this.media = new (__customMediaClass || Media)();
     this.store = getStore(
       this.media,
       this._actionEmitter,


### PR DESCRIPTION
@remigallego This should allow you to construct a Webamp instance with a custom media class:

```JavaScript
import MyCustomMediaClass from "./somewhere";

const webamp = new Webamp({
  // ... other config options
  __customMediaClass: MyCustomMediaClass
});
```

You will have to create a class which is API compatible with `https://github.com/captbaritone/webamp/blob/master/js/media/index.ts`.

If you think this approach looks reasonable, let me know and I can publish a release that includes this commit. There will likely be some issues to work out after we get this hooked up. For example, there will be some methods that you can't reasonably implement, like `getAnalyser`. Let me know what these are and we'll find some kind of solution.
