### PR TITLE
Fix target="_blank"

### DIFF
--- a/js/components/MainWindow/index.tsx
+++ b/js/components/MainWindow/index.tsx
@@ -156,7 +156,7 @@ export class MainWindow extends React.Component<Props> {
             </div>
             <a
               id="about"
-              target="blank"
+              target="_blank"
               href="https://webamp.org/about"
               title="About"
             />


### PR DESCRIPTION
It's tricky because "blank" (without an underscore) will still open a new tab, but it's actually being interpreted as a browsing context name, and so clicking it a second time will replace the previously opened tab (even if navigated away).