### PR TITLE
measure image if we don't have node attributes to use

### DIFF
--- a/experiments/modern/src/App.js
+++ b/experiments/modern/src/App.js
@@ -35,7 +35,7 @@ async function loadImage (imgUrl) {
   return await new Promise(resolve => {
     const img = new Image();
     img.addEventListener("load", function() {
-      resolve([img.width, img.height]);
+      resolve(img);
     });
     img.src = imgUrl;
   });
@@ -65,11 +65,11 @@ async function getSkin() {
         const imgBlob = await img.async("blob");
         const imgUrl = URL.createObjectURL(imgBlob);
         if (w  === undefined || h  === undefined) {
-          let [width, height] = await loadImage(imgUrl);
-          w = width;
-          h = height;
-          x = 0;
-          y = 0;
+          const image = await loadImage(imgUrl);
+          w = image.width;
+          h = image.height;
+          x = (x !== undefined) ? x : 0;
+          y = (y !== undefined) ? y : 0;
         }
         images[id.toLowerCase()] = { file, gammagroup, h, w, x, y, imgUrl };
         break;

--- a/experiments/modern/src/App.js
+++ b/experiments/modern/src/App.js
@@ -31,6 +31,16 @@ const IGNORE_IDS = new Set([
 
 const SkinContext = React.createContext(null);
 
+async function loadImage (imgUrl) {
+  return await new Promise(resolve => {
+    const img = new Image();
+    img.addEventListener("load", function() {
+      resolve([img.width, img.height]);
+    });
+    img.src = imgUrl;
+  });
+}
+
 async function getSkin() {
   const resp = await fetch(
     process.env.PUBLIC_URL + "/skins/CornerAmp_Redux.wal"
@@ -49,11 +59,18 @@ async function getSkin() {
     // TODO: This is probalby only valid if in an `<elements>` node
     switch (node.name) {
       case "bitmap": {
-        const { file, gammagroup, h, id, w, x, y } = node.attributes;
+        let { file, gammagroup, h, id, w, x, y } = node.attributes;
         // TODO: Escape file for regex
         const img = Utils.getCaseInsensitveFile(zip, file);
         const imgBlob = await img.async("blob");
         const imgUrl = URL.createObjectURL(imgBlob);
+        if (w  === undefined || h  === undefined) {
+          let [width, height] = await loadImage(imgUrl);
+          w = width;
+          h = height;
+          x = 0;
+          y = 0;
+        }
         images[id.toLowerCase()] = { file, gammagroup, h, w, x, y, imgUrl };
         break;
       }


### PR DESCRIPTION
not sure this is the ideal way to do this, but was playing around with another skin and it was trying to load images from nodes that didn't define `w/h/x/y`