### PR TITLE
Fix hook variable passing and initial stack setup

### DIFF
--- a/modern/src/Emitter.js
+++ b/modern/src/Emitter.js
@@ -18,7 +18,7 @@ class Emitter {
   }
 
   trigger(eventName, ...args) {
-    this._globalHooks.map(cb => cb(eventName, args));
+    this._globalHooks.map(cb => cb(eventName, ...args));
     if (this._hooks[eventName] == null) {
       return;
     }

--- a/modern/src/maki-interpreter/interpreter.js
+++ b/modern/src/maki-interpreter/interpreter.js
@@ -41,13 +41,13 @@ function main({ runtime, data, system, log, debugHandler }) {
     // const logger = log ? printCommand : logger;
     // TODO: Handle disposing of this.
     // TODO: Handle passing in variables.
-    variable.hook(method.name, () => {
+    variable.hook(method.name, (...args) => {
       // Interpret is a generator that yields before each command is exectued.
       // `handler` is reponsible for `.next()`ing until the program execution is
       // complete (the generator is "done"). In production this is done
       // synchronously. In the debugger, if execution is paused, it's done
       // async.
-      handler(interpret(commandOffset, program, []));
+      handler(interpret(commandOffset, program, args.reverse()));
     });
   });
 

--- a/modern/src/maki-interpreter/variable.js
+++ b/modern/src/maki-interpreter/variable.js
@@ -18,9 +18,11 @@ class Variable {
       this._unsubscribeFromValue();
     }
     if (this.global && this.typeName === "OBJECT" && value !== null) {
-      this._unsubscribeFromValue = value.js_listenToAll((eventName, args) => {
-        this._emitter.trigger(eventName, args);
-      });
+      this._unsubscribeFromValue = value.js_listenToAll(
+        (eventName, ...args) => {
+          this._emitter.trigger(eventName, ...args);
+        }
+      );
     }
     this._value = value;
   }

--- a/modern/src/runtime/MakiObject.js
+++ b/modern/src/runtime/MakiObject.js
@@ -26,7 +26,7 @@ class MakiObject {
   }
 
   js_trigger(eventName, ...args) {
-    this._emitter.trigger(eventName, args);
+    this._emitter.trigger(eventName, ...args);
   }
 
   js_listenToAll(cb) {


### PR DESCRIPTION
Needed to add a few extra spreads, because we were accidentally rewrapping params in arrays.

Need to put hook variables on the stack when executing them