### PR TITLE
Rerender on attribute updates

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -33,7 +33,7 @@ function setupUpdates(node) {
   });
 }
 
-function handleMouseEventDispatch(node, event, eventType, eventName) {
+function handleMouseEventDispatch(node, event, eventName) {
   event.stopPropagation();
 
   let relativeParent = event.target.offsetParent;
@@ -52,8 +52,8 @@ function handleMouseEventDispatch(node, event, eventType, eventName) {
   if (newNode.style.position === "absolute") {
     const newEvent = document.createEvent("MouseEvents");
     newEvent.initMouseEvent(
-      eventType,
-      event.canBubble,
+      event.nativeEvent.type,
+      event.bubbles,
       event.cancelable,
       event.view,
       event.detail,
@@ -76,14 +76,12 @@ function handleMouseEventDispatch(node, event, eventType, eventName) {
 function handleMouseButtonEventDispatch(
   node,
   event,
-  eventType,
   leftEventName,
   rightEventName
 ) {
   handleMouseEventDispatch(
     node,
     event,
-    eventType,
     event.button === 2 ? rightEventName : leftEventName
   );
 }
@@ -96,7 +94,6 @@ function GuiObjectEvents({ Component, node, children }) {
         handleMouseButtonEventDispatch(
           node,
           e,
-          "onMouseDown",
           "onLeftButtonDown",
           "onRightButtonDown"
         )
@@ -105,7 +102,6 @@ function GuiObjectEvents({ Component, node, children }) {
         handleMouseButtonEventDispatch(
           node,
           e,
-          "onMouseUp",
           "onLeftButtonUp",
           "onRightButtonUp"
         )
@@ -114,25 +110,16 @@ function GuiObjectEvents({ Component, node, children }) {
         handleMouseButtonEventDispatch(
           node,
           e,
-          "onDoubleClick",
           "onLeftButtonDblClk",
           "onRightButtonDblClk"
         )
       }
-      onMouseMove={e =>
-        handleMouseEventDispatch(node, e, "onMouseMove", "onMouseMove")
-      }
-      onMouseEnter={e =>
-        handleMouseEventDispatch(node, e, "onMouseEnter", "onEnterArea")
-      }
-      onMouseLeave={e =>
-        handleMouseEventDispatch(node, e, "onMouseLeave", "onLeaveArea")
-      }
+      onMouseMove={e => handleMouseEventDispatch(node, e, "onMouseMove")}
+      onMouseEnter={e => handleMouseEventDispatch(node, e, "onEnterArea")}
+      onMouseLeave={e => handleMouseEventDispatch(node, e, "onLeaveArea")}
       onDragEnter={e => node.js_trigger("onDragEnter")}
       onDragLeave={e => node.js_trigger("onDragLeave")}
-      onDragOver={e =>
-        handleMouseEventDispatch(node, e, "onDragOver", "onDragOver")
-      }
+      onDragOver={e => handleMouseEventDispatch(node, e, "onDragOver")}
       onKeyUp={e => node.js_trigger("onKeyUp", e.keyCode)}
       onKeyDown={e => node.js_trigger("onKeyDown", e.keyCode)}
     >

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -43,7 +43,7 @@ function handleMouseEventDispatch(node, event, eventName) {
 
   event.target.style.display = "none";
   const newNode = document.elementFromPoint(event.clientX, event.clientY);
-  if (newNode.style.position === "absolute") {
+  if (newNode !== document.body && newNode.tagName !== "HTML") {
     const newEvent = document.createEvent("MouseEvents");
     newEvent.initMouseEvent(
       event.nativeEvent.type,

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -197,6 +197,9 @@ function Layer({ node, id, image, children, x, y }) {
   if (img.h !== undefined) {
     params.height = Number(img.h);
   }
+  if (id === "volumethumb") {
+    params.border = "1px solid black";
+  }
   return (
     <>
       <img

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -33,7 +33,9 @@ function setupUpdates(node) {
   });
 }
 
-function handleMouseEventDispatch(node, event, eventName) {
+function handleMouseEventDispatch(node, event, eventType, eventName) {
+  event.stopPropagation();
+
   let relativeParent = event.target.offsetParent;
   while (
     relativeParent.offsetParent &&
@@ -44,17 +46,44 @@ function handleMouseEventDispatch(node, event, eventName) {
   const x = event.clientX - relativeParent.offsetLeft;
   const y = event.clientY - relativeParent.offsetTop;
   node.js_trigger(eventName, x, y);
+
+  event.target.style.display = "none";
+  const newNode = document.elementFromPoint(event.clientX, event.clientY);
+  if (newNode.style.position === "absolute") {
+    const newEvent = document.createEvent("MouseEvents");
+    newEvent.initMouseEvent(
+      eventType,
+      event.canBubble,
+      event.cancelable,
+      event.view,
+      event.detail,
+      event.screenX,
+      event.screenY,
+      event.clientX,
+      event.clientY,
+      event.ctrlKey,
+      event.altKey,
+      event.shiftKey,
+      event.metaKey,
+      event.button,
+      event.relatedTarget
+    );
+    newNode.dispatchEvent(newEvent);
+  }
+  event.target.style.display = "";
 }
 
 function handleMouseButtonEventDispatch(
   node,
   event,
+  eventType,
   leftEventName,
   rightEventName
 ) {
   handleMouseEventDispatch(
     node,
     event,
+    eventType,
     event.button === 2 ? rightEventName : leftEventName
   );
 }
@@ -67,6 +96,7 @@ function GuiObjectEvents({ Component, node, children }) {
         handleMouseButtonEventDispatch(
           node,
           e,
+          "onMouseDown",
           "onLeftButtonDown",
           "onRightButtonDown"
         )
@@ -75,6 +105,7 @@ function GuiObjectEvents({ Component, node, children }) {
         handleMouseButtonEventDispatch(
           node,
           e,
+          "onMouseUp",
           "onLeftButtonUp",
           "onRightButtonUp"
         )
@@ -83,16 +114,25 @@ function GuiObjectEvents({ Component, node, children }) {
         handleMouseButtonEventDispatch(
           node,
           e,
+          "onDoubleClick",
           "onLeftButtonDblClk",
           "onRightButtonDblClk"
         )
       }
-      onMouseMove={e => handleMouseEventDispatch(node, e, "onMouseMove")}
-      onMouseEnter={e => handleMouseEventDispatch(node, e, "onEnterArea")}
-      onMouseLeave={e => handleMouseEventDispatch(node, e, "onLeaveArea")}
+      onMouseMove={e =>
+        handleMouseEventDispatch(node, e, "onMouseMove", "onMouseMove")
+      }
+      onMouseEnter={e =>
+        handleMouseEventDispatch(node, e, "onMouseEnter", "onEnterArea")
+      }
+      onMouseLeave={e =>
+        handleMouseEventDispatch(node, e, "onMouseLeave", "onLeaveArea")
+      }
       onDragEnter={e => node.js_trigger("onDragEnter")}
       onDragLeave={e => node.js_trigger("onDragLeave")}
-      onDragOver={e => handleMouseEventDispatch(node, e, "onDragOver")}
+      onDragOver={e =>
+        handleMouseEventDispatch(node, e, "onDragOver", "onDragOver")
+      }
       onKeyUp={e => node.js_trigger("onKeyUp", e.keyCode)}
       onKeyDown={e => node.js_trigger("onKeyDown", e.keyCode)}
     >

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useReducer } from "react";
 import JSZip from "jszip";
 import "./App.css";
 import * as Utils from "./utils";
@@ -22,10 +22,27 @@ async function getSkin() {
   return await initialize(zip, skinXml);
 }
 
+function setupUpdates(node) {
+  const [ignored, forceUpdate] = useReducer(x => x + 1, 0);
+  let once = true;
+  node.js_listen("js_update", () => {
+    if (once) {
+      once = false;
+      forceUpdate();
+    }
+  });
+}
+
 function handleMouseEventDispatch(node, event, eventName) {
-  const rect = event.target.getBoundingClientRect();
-  const x = event.clientX - rect.left;
-  const y = event.clientY - rect.top;
+  let relativeParent = event.target.offsetParent;
+  while (
+    relativeParent.offsetParent &&
+    relativeParent.offsetParent !== document.body
+  ) {
+    relativeParent = relativeParent.offsetParent;
+  }
+  const x = event.clientX - relativeParent.offsetLeft;
+  const y = event.clientY - relativeParent.offsetTop;
   node.js_trigger(eventName, x, y);
 }
 
@@ -42,7 +59,8 @@ function handleMouseButtonEventDispatch(
   );
 }
 
-function GuiObjectEvents({ node, children }) {
+function GuiObjectEvents({ Component, node, children }) {
+  setupUpdates(node);
   return (
     <div
       onMouseDown={e =>
@@ -78,7 +96,9 @@ function GuiObjectEvents({ node, children }) {
       onKeyUp={e => node.js_trigger("onKeyUp", e.keyCode)}
       onKeyDown={e => node.js_trigger("onKeyDown", e.keyCode)}
     >
-      {children}
+      <Component node={node} {...node.attributes}>
+        {children}
+      </Component>
     </div>
   );
 }
@@ -302,10 +322,8 @@ function XmlNode({ node }) {
     return null;
   }
   return (
-    <GuiObjectEvents node={node}>
-      <Component node={node} {...attributes}>
-        {children}
-      </Component>
+    <GuiObjectEvents Component={Component} node={node}>
+      {children}
     </GuiObjectEvents>
   );
 }

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from "react";
+import React, { useEffect, useReducer } from "react";
 import JSZip from "jszip";
 import "./App.css";
 import * as Utils from "./utils";
@@ -24,13 +24,7 @@ async function getSkin() {
 
 function setupUpdates(node) {
   const [ignored, forceUpdate] = useReducer(x => x + 1, 0);
-  let once = true;
-  node.js_listen("js_update", () => {
-    if (once) {
-      once = false;
-      forceUpdate();
-    }
-  });
+  useEffect(() => node.js_listen("js_update", forceUpdate));
 }
 
 function handleMouseEventDispatch(node, event, eventName) {

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -28,8 +28,11 @@ function setupUpdates(node) {
 }
 
 function handleMouseEventDispatch(node, event, eventName) {
+  // We manually propagate the event using x/y coordinates to handle absolute positioned elements
   event.stopPropagation();
 
+  // In order to properly calculate the x/y coordinates like MAKI does we need
+  // to find the top level absolute positioned element and calculate based off of that
   let relativeParent = event.target.offsetParent;
   while (
     relativeParent.offsetParent &&
@@ -41,6 +44,9 @@ function handleMouseEventDispatch(node, event, eventName) {
   const y = event.clientY - relativeParent.offsetTop;
   node.js_trigger(eventName, x, y);
 
+  // We need to hide the current element to calcualte the other nodes that are behind it
+  // This wouldn't normally be necessary with bubbling, but we need to handle absolute
+  // positioned sibling elements to replicate how MAKI works
   event.target.style.display = "none";
   const newNode = document.elementFromPoint(event.clientX, event.clientY);
   if (newNode !== document.body && newNode.tagName !== "HTML") {

--- a/modern/src/runtime/GuiObject.js
+++ b/modern/src/runtime/GuiObject.js
@@ -35,6 +35,7 @@ class GuiObject extends MakiObject {
 
   setxmlparam(param, value) {
     this.attributes[param] = value;
+    this.js_trigger("js_update");
     return value;
   }
 
@@ -55,19 +56,19 @@ class GuiObject extends MakiObject {
   }
 
   gettop() {
-    return this.attributes.y || 0;
+    return Number(this.attributes.y) || 0;
   }
 
   getleft() {
-    return this.attributes.x || 0;
+    return Number(this.attributes.x) || 0;
   }
 
   getheight() {
-    return this.attributes.h || 0;
+    return Number(this.attributes.h) || 0;
   }
 
   getwidth() {
-    return this.attributes.w || 0;
+    return Number(this.attributes.w) || 0;
   }
 
   resize(x, y, w, h) {

--- a/modern/src/runtime/MakiObject.js
+++ b/modern/src/runtime/MakiObject.js
@@ -29,6 +29,10 @@ class MakiObject {
     this._emitter.trigger(eventName, ...args);
   }
 
+  js_listen(eventName, cb) {
+    return this._emitter.listen(eventName, cb);
+  }
+
   js_listenToAll(cb) {
     return this._emitter.listenToAll(cb);
   }


### PR DESCRIPTION
It feels hacky, but I'm not sure if there is a better/different way to do it.

Main "problems" we needed to overcome:

Determining x/y positioning the same way MAKI does, which involves finding the top level absolutely positioned ancestor
Dispatching events to absolutely positioned elements at the same x/y coordinates