### PR TITLE
Fix event x/y by finding container node

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -23,9 +23,19 @@ async function getSkin() {
 }
 
 function handleMouseEventDispatch(node, event, eventName) {
-  const rect = event.target.getBoundingClientRect();
-  const x = event.clientX - rect.left;
-  const y = event.clientY - rect.top;
+  event.stopPropagation();
+
+  // In order to properly calculate the x/y coordinates like MAKI does we need
+  // to find the top level absolute positioned element and calculate based off of that
+  let relativeParent = event.target.offsetParent;
+  while (
+    relativeParent.offsetParent &&
+    relativeParent.offsetParent !== document.body
+  ) {
+    relativeParent = relativeParent.offsetParent;
+  }
+  const x = event.clientX - relativeParent.offsetLeft;
+  const y = event.clientY - relativeParent.offsetTop;
   node.js_trigger(eventName, x, y);
 }
 

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -26,16 +26,10 @@ function handleMouseEventDispatch(node, event, eventName) {
   event.stopPropagation();
 
   // In order to properly calculate the x/y coordinates like MAKI does we need
-  // to find the top level absolute positioned element and calculate based off of that
-  let relativeParent = event.target.offsetParent;
-  while (
-    relativeParent.offsetParent &&
-    relativeParent.offsetParent !== document.body
-  ) {
-    relativeParent = relativeParent.offsetParent;
-  }
-  const x = event.clientX - relativeParent.offsetLeft;
-  const y = event.clientY - relativeParent.offsetTop;
+  // to find the container element and calculate based off of that
+  const container = Utils.findParentNodeOfType(node, ["container"]);
+  const x = event.clientX - container.getleft();
+  const y = event.clientY - container.gettop();
   node.js_trigger(eventName, x, y);
 }
 

--- a/modern/src/runtime/GuiObject.js
+++ b/modern/src/runtime/GuiObject.js
@@ -55,19 +55,19 @@ class GuiObject extends MakiObject {
   }
 
   gettop() {
-    return this.attributes.y || 0;
+    return Number(this.attributes.y) || 0;
   }
 
   getleft() {
-    return this.attributes.x || 0;
+    return Number(this.attributes.x) || 0;
   }
 
   getheight() {
-    return this.attributes.h || 0;
+    return Number(this.attributes.h) || 0;
   }
 
   getwidth() {
-    return this.attributes.w || 0;
+    return Number(this.attributes.w) || 0;
   }
 
   resize(x, y, w, h) {


### PR DESCRIPTION
Need to calculate x/y based off of the "top" absolute positioned element, so follow `offsetParent` up the chain. Probably gets rid of the forced layout too