### PR TITLE
Fix hook eventNames to be case insensitive

### DIFF
--- a/modern/src/maki-interpreter/variable.js
+++ b/modern/src/maki-interpreter/variable.js
@@ -20,7 +20,7 @@ class Variable {
     if (this.global && this.typeName === "OBJECT" && value !== null) {
       this._unsubscribeFromValue = value.js_listenToAll(
         (eventName, ...args) => {
-          this._emitter.trigger(eventName, ...args);
+          this._emitter.trigger(eventName.toLowerCase(), ...args);
         }
       );
     }
@@ -28,7 +28,7 @@ class Variable {
   }
 
   hook(eventName, cb) {
-    this._emitter.listen(eventName, cb);
+    this._emitter.listen(eventName.toLowerCase(), cb);
   }
 
   dispose() {

--- a/modern/src/runtime/MakiObject.js
+++ b/modern/src/runtime/MakiObject.js
@@ -26,7 +26,7 @@ class MakiObject {
   }
 
   js_trigger(eventName, ...args) {
-    this._emitter.trigger(eventName, ...args);
+    this._emitter.trigger(eventName.toLowerCase(), ...args);
   }
 
   js_listenToAll(cb) {


### PR DESCRIPTION
Like everything else in MAKI, hook eventNames are case insensitive