### PR TITLE
MakiObject classname really should be Object

### DIFF
--- a/modern/src/runtime/MakiObject.js
+++ b/modern/src/runtime/MakiObject.js
@@ -71,7 +71,7 @@ class MakiObject {
    * @ret The class name.
    */
   getclassname() {
-    return "MakiObject";
+    return "Object";
   }
 
   /**


### PR DESCRIPTION
tests are angry, I guess the classname really is `Object` even though we call it a MakiObject