### PR TITLE
Fix script group finding

### DIFF
--- a/modern/src/Actions.ts
+++ b/modern/src/Actions.ts
@@ -57,7 +57,7 @@ function gotSkinZip(zip: JSZip, store: ModernStore) {
           }
           const scriptGroup = Utils.findParentNodeOfType(
             node,
-            new Set(["group", "JsWinampAbstractionLayer", "WasabiXML"])
+            new Set(["group", "WinampAbstractionLayer", "WasabiXML"])
           );
           const system = new System(scriptGroup, store);
           run({


### PR DESCRIPTION
So this would have been caught by tests, because I found it when checking that my tests worked hah.

findParentNodeOfType is checking against the underlying XML node name, not the object classname, so we still need to use `WinampAbstractionLayer`.