### PR TITLE
Move all image lookups to XML tree and support directly specifying image file

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -280,7 +280,7 @@ function Layout({
   );
 }
 
-function Layer({ node, id, image, children, x, y, w, h }) {
+function Layer({ node, id, image, children, x, y }) {
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -276,7 +276,7 @@ function Layout({
   );
 }
 
-function Layer({ id, node, js_assets, image, children, x, y }) {
+function Layer({ id, node, js_assets, image, x, y }) {
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -190,6 +190,7 @@ function Container(props) {
 
 function Layout({
   id,
+  node,
   js_assets,
   background,
   // desktopalpha,
@@ -275,7 +276,7 @@ function Layout({
   );
 }
 
-function Layer({ id, js_assets, image, children, x, y }) {
+function Layer({ id, node, js_assets, image, children, x, y }) {
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -190,6 +190,7 @@ function Container(props) {
 
 function Layout({
   id,
+  js_assets,
   background,
   // desktopalpha,
   drawBackground,
@@ -209,7 +210,7 @@ function Layout({
   }
 
   if (drawBackground) {
-    const image = background;
+    const image = js_assets["background"];
     if (image == null) {
       console.warn(
         "Unable to find image to render. Rendering null",
@@ -274,12 +275,13 @@ function Layout({
   );
 }
 
-function Layer({ id, image, children, x, y }) {
+function Layer({ id, js_assets, image, children, x, y }) {
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;
   }
-  if (image == null) {
+  const img = js_assets["image"];
+  if (img == null) {
     console.warn("Unable to find image to render. Rendering null", image);
     return null;
   }
@@ -290,20 +292,20 @@ function Layer({ id, image, children, x, y }) {
   if (y !== undefined) {
     params.top = Number(y);
   }
-  if (image.x !== undefined) {
-    params.backgroundPositionX = -Number(image.x);
+  if (img.x !== undefined) {
+    params.backgroundPositionX = -Number(img.x);
   }
-  if (image.y !== undefined) {
-    params.backgroundPositionY = -Number(image.y);
+  if (img.y !== undefined) {
+    params.backgroundPositionY = -Number(img.y);
   }
-  if (image.w !== undefined) {
-    params.width = Number(image.w);
+  if (img.w !== undefined) {
+    params.width = Number(img.w);
   }
-  if (image.h !== undefined) {
-    params.height = Number(image.h);
+  if (img.h !== undefined) {
+    params.height = Number(img.h);
   }
-  if (image.imgUrl !== undefined) {
-    params.backgroundImage = `url(${image.imgUrl}`;
+  if (img.imgUrl !== undefined) {
+    params.backgroundImage = `url(${img.imgUrl}`;
   }
   return (
     <GuiObjectEvents node={node}>
@@ -321,6 +323,7 @@ function Layer({ id, image, children, x, y }) {
 
 function Button({
   id,
+  js_assets,
   image,
   // action,
   x,
@@ -331,7 +334,7 @@ function Button({
 }) {
   const [down, setDown] = React.useState(false);
   // TODO: These seem to be switching too fast
-  const img = down && downImage ? downImage : image;
+  const img = down && downImage ? js_assets["downimage"] : js_assets["image"];
   if (img == null) {
     console.warn("Got a Button without a img. Rendering null", id);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -210,7 +210,7 @@ function Layout({
   }
 
   if (drawBackground) {
-    const image = js_assets["background"];
+    const image = js_assets.background;
     if (image == null) {
       console.warn(
         "Unable to find image to render. Rendering null",
@@ -280,7 +280,7 @@ function Layer({ id, js_assets, image, children, x, y }) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;
   }
-  const img = js_assets["image"];
+  const img = js_assets.image;
   if (img == null) {
     console.warn("Unable to find image to render. Rendering null", image);
     return null;
@@ -324,7 +324,7 @@ function Layer({ id, js_assets, image, children, x, y }) {
 function Button({
   id,
   js_assets,
-  image,
+  // image,
   // action,
   x,
   y,
@@ -334,7 +334,7 @@ function Button({
 }) {
   const [down, setDown] = React.useState(false);
   // TODO: These seem to be switching too fast
-  const img = down && downImage ? js_assets["downimage"] : js_assets["image"];
+  const img = down && downImage ? js_assets.downimage : js_assets.image;
   if (img == null) {
     console.warn("Got a Button without a img. Rendering null", id);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -210,7 +210,12 @@ function Layout({
   }
 
   if (drawBackground) {
-    const image = node.js_imageLookup(background);
+    let image;
+    if (Utils.isObject(background)) {
+      image = background;
+    } else {
+      image = node.js_imageLookup(background);
+    }
     if (image == null) {
       console.warn(
         "Unable to find image to render. Rendering null",
@@ -275,12 +280,17 @@ function Layout({
   );
 }
 
-function Layer({ node, id, image, x, y }) {
+function Layer({ node, id, image, children, x, y, w, h }) {
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;
   }
-  const img = node.js_imageLookup(image.toLowerCase());
+  let img;
+  if (Utils.isObject(image)) {
+    img = image;
+  } else {
+    img = node.js_imageLookup(image.toLowerCase());
+  }
   if (img == null) {
     console.warn("Unable to find image to render. Rendering null", image);
     return null;
@@ -338,7 +348,12 @@ function Button({
     return null;
   }
   // TODO: These seem to be switching too fast
-  const img = node.js_imageLookup(imgId);
+  let img;
+  if (Utils.isObject(imgId)) {
+    img = imgId;
+  } else {
+    img = node.js_imageLookup(imgId);
+  }
   if (img == null) {
     console.warn("Unable to find image to render. Rendering null", image);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -279,8 +279,7 @@ function Layer({ id, image, children, x, y }) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;
   }
-  const img = image;
-  if (img == null) {
+  if (image == null) {
     console.warn("Unable to find image to render. Rendering null", image);
     return null;
   }
@@ -291,20 +290,20 @@ function Layer({ id, image, children, x, y }) {
   if (y !== undefined) {
     params.top = Number(y);
   }
-  if (img.x !== undefined) {
-    params.backgroundPositionX = -Number(img.x);
+  if (image.x !== undefined) {
+    params.backgroundPositionX = -Number(image.x);
   }
-  if (img.y !== undefined) {
-    params.backgroundPositionY = -Number(img.y);
+  if (image.y !== undefined) {
+    params.backgroundPositionY = -Number(image.y);
   }
-  if (img.w !== undefined) {
-    params.width = Number(img.w);
+  if (image.w !== undefined) {
+    params.width = Number(image.w);
   }
-  if (img.h !== undefined) {
-    params.height = Number(img.h);
+  if (image.h !== undefined) {
+    params.height = Number(image.h);
   }
-  if (img.imgUrl !== undefined) {
-    params.backgroundImage = `url(${img.imgUrl}`;
+  if (image.imgUrl !== undefined) {
+    params.backgroundImage = `url(${image.imgUrl}`;
   }
   return (
     <GuiObjectEvents node={node}>

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -189,7 +189,6 @@ function Container(props) {
 }
 
 function Layout({
-  node,
   id,
   background,
   // desktopalpha,
@@ -275,7 +274,7 @@ function Layout({
   );
 }
 
-function Layer({ node, id, image, children, x, y }) {
+function Layer({ id, image, children, x, y }) {
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -210,12 +210,7 @@ function Layout({
   }
 
   if (drawBackground) {
-    let image;
-    if (Utils.isObject(background)) {
-      image = background;
-    } else {
-      image = node.js_imageLookup(background);
-    }
+    const image = background;
     if (image == null) {
       console.warn(
         "Unable to find image to render. Rendering null",
@@ -285,12 +280,7 @@ function Layer({ node, id, image, children, x, y }) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;
   }
-  let img;
-  if (Utils.isObject(image)) {
-    img = image;
-  } else {
-    img = node.js_imageLookup(image.toLowerCase());
-  }
+  const img = image;
   if (img == null) {
     console.warn("Unable to find image to render. Rendering null", image);
     return null;
@@ -342,20 +332,10 @@ function Button({
   node,
 }) {
   const [down, setDown] = React.useState(false);
-  const imgId = down && downImage ? downImage : image;
-  if (imgId == null) {
-    console.warn("Got a Button without a imgId. Rendering null", id);
-    return null;
-  }
   // TODO: These seem to be switching too fast
-  let img;
-  if (Utils.isObject(imgId)) {
-    img = imgId;
-  } else {
-    img = node.js_imageLookup(imgId);
-  }
+  const img = down && downImage ? downImage : image;
   if (img == null) {
-    console.warn("Unable to find image to render. Rendering null", image);
+    console.warn("Got a Button without a img. Rendering null", id);
     return null;
   }
 

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -187,8 +187,8 @@ async function nodeImageLookup(node, root, zip) {
     node.attributes.js_assets = {};
   }
   await Promise.all(
-    imageAttributes.map(async path => {
-      const image = node.attributes[path];
+    imageAttributes.map(async attribute => {
+      const image = node.attributes[attribute];
       if (!image || !Utils.isString(image)) {
         return;
       }
@@ -211,7 +211,7 @@ async function nodeImageLookup(node, root, zip) {
           console.warn("Unable to find image:", image);
         }
       }
-      node.attributes.js_assets[path.toLowerCase()] = img;
+      node.attributes.js_assets[attribute.toLowerCase()] = img;
     })
   );
 }

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -41,7 +41,28 @@ async function prepareMakiImage(node, zip, file) {
   };
 }
 
-async function createWithImageLookups(Klass, node, parent, zip, imagePaths) {
+function imagePathsFromNode(node) {
+  switch (node.name) {
+    case "layer": {
+      return ["image"];
+    }
+    case "layout": {
+      return ["background"];
+    }
+    case "button": {
+      return ["image", "downImage"];
+    }
+    case "togglebutton": {
+      return ["image", "downImage"];
+    }
+    default: {
+      return [];
+    }
+  }
+}
+
+async function createWithImageLookups(Klass, node, parent, zip, store) {
+  const imagePaths = imagePathsFromNode(node);
   imagePaths.forEach(async path => {
     const image = node.attributes[path];
     if (Utils.isString(image) && image.endsWith(".png")) {
@@ -50,7 +71,7 @@ async function createWithImageLookups(Klass, node, parent, zip, imagePaths) {
     }
   });
 
-  return new Klass(node, parent);
+  return new Klass(node, parent, undefined, store);
 }
 
 const noop = (node, parent, zip, store) =>
@@ -76,18 +97,15 @@ const parsers = {
     new JsGammaSet(node, parent, undefined, store),
   color: noop,
   layer: async (node, parent, zip, store) =>
-    createWithImageLookups(Layer, node, parent, zip, store, ["image"]),
+    createWithImageLookups(Layer, node, parent, zip, store),
   layoutstatus: noop,
   hideobject: noop,
   button: async (node, parent, zip, store) =>
-    createWithImageLookups(Button, node, parent, zip, store, [
-      "image",
-      "downImage",
-    ]),
+    createWithImageLookups(Button, node, parent, zip, store),
   group: (node, parent, zip, store) =>
     new Group(node, parent, undefined, store),
   layout: async (node, parent, zip, store) =>
-    createWithImageLookups(Layout, node, parent, zip, store, ["background"]),
+    createWithImageLookups(Layout, node, parent, zip, store),
   sendparams: noop,
   elements: (node, parent, zip, store) =>
     new JsElements(node, parent, undefined, store),
@@ -114,10 +132,7 @@ const parsers = {
     new Component(node, parent, undefined, store),
   text: (node, parent, zip, store) => new Text(node, parent, undefined, store),
   togglebutton: async (node, parent, zip, store) =>
-    createWithImageLookups(ToggleButton, node, parent, zip, store, [
-      "image",
-      "downImage",
-    ]),
+    createWithImageLookups(ToggleButton, node, parent, zip, store),
   status: (node, parent, zip, store) =>
     new Status(node, parent, undefined, store),
   bitmapfont: noop,

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -183,6 +183,9 @@ async function nodeImageLookup(node, root, zip) {
   if (!imageAttributes || imageAttributes.length === 0) {
     return;
   }
+  if (!node.attributes.js_assets) {
+    node.attributes.js_assets = {};
+  }
   await Promise.all(
     imageAttributes.map(async path => {
       const image = node.attributes[path];
@@ -208,7 +211,7 @@ async function nodeImageLookup(node, root, zip) {
           console.warn("Unable to find image:", image);
         }
       }
-      node.attributes[path] = img;
+      node.attributes.js_assets[path.toLowerCase()] = img;
     })
   );
 }

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -180,35 +180,37 @@ async function parseChildren(node, children, zip, store) {
 
 async function nodeImageLookup(node, root, zip) {
   const imageAttributes = imageAttributesFromNode(node);
-  if (imageAttributes) {
-    await Promise.all(
-      imageAttributes.map(async path => {
-        const image = node.attributes[path];
-        if (image && Utils.isString(image)) {
-          let img;
-          if (image.endsWith(".png")) {
-            img = await prepareMakiImage(node, zip, image);
-          } else {
-            const elementNode = Utils.findXmlElementById(node, image, root);
-            if (elementNode) {
-              img = await prepareMakiImage(
-                elementNode,
-                zip,
-                elementNode.attributes.file
-              );
-
-              const { x, y } = elementNode.attributes;
-              img.x = x !== undefined ? x : 0;
-              img.y = y !== undefined ? y : 0;
-            } else {
-              console.warn("Unable to find image:", image);
-            }
-          }
-          node.attributes[path] = img;
-        }
-      })
-    );
+  if (!imageAttributes || imageAttributes.length === 0) {
+    return;
   }
+  await Promise.all(
+    imageAttributes.map(async path => {
+      const image = node.attributes[path];
+      if (!image || !Utils.isString(image)) {
+        return;
+      }
+      let img;
+      if (image.endsWith(".png")) {
+        img = await prepareMakiImage(node, zip, image);
+      } else {
+        const elementNode = Utils.findXmlElementById(node, image, root);
+        if (elementNode) {
+          img = await prepareMakiImage(
+            elementNode,
+            zip,
+            elementNode.attributes.file
+          );
+
+          const { x, y } = elementNode.attributes;
+          img.x = x !== undefined ? x : 0;
+          img.y = y !== undefined ? y : 0;
+        } else {
+          console.warn("Unable to find image:", image);
+        }
+      }
+      node.attributes[path] = img;
+    })
+  );
 }
 
 async function applyImageLookups(root, zip) {

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -42,16 +42,14 @@ async function prepareMakiImage(node, zip, file) {
 }
 
 function imagePathsFromNode(node) {
-  switch (node.name) {
+  switch (node.name.toLowerCase()) {
     case "layer": {
       return ["image"];
     }
     case "layout": {
       return ["background"];
     }
-    case "button": {
-      return ["image", "downImage"];
-    }
+    case "button":
     case "togglebutton": {
       return ["image", "downImage"];
     }
@@ -220,7 +218,7 @@ function nodeImageLookup(node) {
 
 function applyImageLookups(root) {
   Utils.asyncTreeFlatMap(root, node => {
-    nodeImageLookup(node, ["image"]);
+    nodeImageLookup(node);
     return node;
   });
 }

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -204,6 +204,27 @@ async function parseChildren(node, children, zip, store) {
   node.js_addChildren(filteredChildren);
 }
 
+function nodeImageLookup(node) {
+  const imagePaths = imagePathsFromNode(node);
+  imagePaths.forEach(path => {
+    const image = node.attributes[path];
+    let img;
+    if (Utils.isString(image)) {
+      img = node.js_imageLookup(image.toLowerCase());
+    } else {
+      img = image;
+    }
+    node.attributes[path] = img;
+  });
+}
+
+function applyImageLookups(root) {
+  Utils.asyncTreeFlatMap(root, node => {
+    nodeImageLookup(node, ["image"]);
+    return node;
+  });
+}
+
 async function applyGroupDefs(root) {
   await Utils.asyncTreeFlatMap(root, async node => {
     switch (node.name) {
@@ -245,6 +266,7 @@ async function initialize(zip, skinXml, store) {
     store
   );
   await parseChildren(root, xmlRoot.children, zip, store);
+  applyImageLookups(root);
   await applyGroupDefs(root);
   return root;
 }

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -64,7 +64,7 @@ async function createWithImageLookups(Klass, node, parent, zip, store) {
   const imagePaths = imagePathsFromNode(node);
   imagePaths.forEach(async path => {
     const image = node.attributes[path];
-    if (Utils.isString(image) && image.endsWith(".png")) {
+    if (image && Utils.isString(image) && image.endsWith(".png")) {
       const imageAnnotations = await prepareMakiImage(node, zip, image);
       node.attributes[path] = imageAnnotations;
     }
@@ -208,7 +208,7 @@ function nodeImageLookup(node) {
   imagePaths.forEach(path => {
     const image = node.attributes[path];
     let img;
-    if (Utils.isString(image)) {
+    if (image && Utils.isString(image)) {
       img = node.js_imageLookup(image.toLowerCase());
     } else {
       img = image;

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -41,7 +41,7 @@ async function prepareMakiImage(node, zip, file) {
   };
 }
 
-function imagePathsFromNode(node) {
+function imageAttributesFromNode(node) {
   if (!node.name) return [];
   switch (node.name.toLowerCase()) {
     case "layer": {
@@ -179,10 +179,10 @@ async function parseChildren(node, children, zip, store) {
 }
 
 async function nodeImageLookup(node, root, zip) {
-  const imagePaths = imagePathsFromNode(node);
-  if (imagePaths) {
+  const imageAttributes = imageAttributesFromNode(node);
+  if (imageAttributes) {
     await Promise.all(
-      imagePaths.map(async path => {
+      imageAttributes.map(async path => {
         const image = node.attributes[path];
         if (image && Utils.isString(image)) {
           let img;

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -42,6 +42,7 @@ async function prepareMakiImage(node, zip, file) {
 }
 
 function imagePathsFromNode(node) {
+  if (!node.name) return [];
   switch (node.name.toLowerCase()) {
     case "layer": {
       return ["image"];

--- a/modern/src/runtime/MakiObject.ts
+++ b/modern/src/runtime/MakiObject.ts
@@ -68,15 +68,6 @@ class MakiObject {
     this._emitter.dispose();
   }
 
-  js_imageLookup(id: string) {
-    const element = Utils.findElementById(this, id);
-    if (element) {
-      return element.js_annotations;
-    }
-
-    return null;
-  }
-
   js_groupdefLookup(id: string) {
     const groupdef = Utils.findGroupDefById(this, id);
     if (groupdef) {

--- a/modern/src/utils.ts
+++ b/modern/src/utils.ts
@@ -303,6 +303,8 @@ export function findXmlElementById(node, id, root) {
   if (root.uid === node.uid) {
     // Search ends if we find the node that initiated the search, since it means we weren't able to
     // find the match in its scope
+    // Return the node itself as a kind of sentinel value to look for, since finding the node is an
+    // ending condition for the search
     return node;
   } else if (root.name === "elements") {
     const element = findDirectDescendantById(root, id);

--- a/modern/src/utils.ts
+++ b/modern/src/utils.ts
@@ -18,7 +18,7 @@ export function isPromise(obj) {
 }
 
 export function isString(obj) {
-  return obj && typeof obj === "string";
+  return typeof obj === "string";
 }
 
 export function isObject(obj) {

--- a/modern/src/utils.ts
+++ b/modern/src/utils.ts
@@ -237,9 +237,9 @@ export function findDescendantByTypeAndId(node, type, id) {
 }
 
 function findDirectDescendantById(node, id) {
-  const idLC = id.toLowerCase();
+  const lowerCaseId = id.toLowerCase();
   return node.children.find(
-    item => item.attributes && item.attributes.id.toLowerCase() === idLC
+    item => item.attributes && item.attributes.id.toLowerCase() === lowerCaseId
   );
 }
 

--- a/modern/src/utils.ts
+++ b/modern/src/utils.ts
@@ -294,8 +294,11 @@ export function findGroupDefById(node, id) {
   });
 }
 
-// Search up the tree for <Elements> nodes that are in node's lexical scope.
-// return the first child of an <Elements> that matches id
+// Search down the tree for <Elements> nodes that are in node's lexical scope.
+// return the first child of an <Elements> that matches id unless we find
+// node first, in that case we didn't find the element
+// TODO: this might be overly generous, including some definitions that
+// shouldn't be accessible. But it's working for now :-X
 export function findXmlElementById(node, id, root) {
   if (root.uid === node.uid) {
     // Search ends if we find the node that initiated the search, since it means we weren't able to

--- a/modern/src/utils.ts
+++ b/modern/src/utils.ts
@@ -17,6 +17,14 @@ export function isPromise(obj) {
   return obj && typeof obj.then === "function";
 }
 
+export function isString(obj) {
+  return obj && typeof obj === "string";
+}
+
+export function isObject(obj) {
+  return obj === Object(obj);
+}
+
 // Convert windows filename slashes to forward slashes
 function fixFilenameSlashes(filename) {
   return filename.replace(/\\/g, "/");


### PR DESCRIPTION
We need to handle components that specify their images directly with file locations in the zip as opposed to id lookups.

I had wanted to condense all the image lookup (including the tree lookups) into the initialize, but ran into a snag. Because of the way we construct the tree, we cannot to the tree lookup as we are constructing the nodes. I guess I could add it as a second pass after the tree creation, similar to groupdefs, but that felt ugly, so I left it. Let me know what you think