### PR TITLE
Add some generic methods for dealing with selectors

### DIFF
--- a/modern/src/MakiSelectors.ts
+++ b/modern/src/MakiSelectors.ts
@@ -1,14 +1,18 @@
 import * as Utils from "./utils";
 
-function findNodeByUid(state, uid) {
-  return Utils.findInTree(state.xmlTree, node => {
-    return node.uid === uid;
-  });
+function findNodeByUid(uid) {
+  // TODO: Do some clever caching here.
+  return state => {
+    return Utils.findInTree(state.xmlTree, node => {
+      return node.uid === uid;
+    });
+  };
 }
 
 export function getTop(uid) {
+  const findNodeInState = findNodeByUid(uid);
   return state => {
-    const node = findNodeByUid(state, uid);
+    const node = findNodeInState(state);
     return Number(node.attributes.y) || 0;
   };
 }

--- a/modern/src/runtime/GuiObject.js
+++ b/modern/src/runtime/GuiObject.js
@@ -11,6 +11,25 @@ class GuiObject extends MakiObject {
     super(node, parent, annotations, store);
 
     this.visible = true;
+    this._selectorCache = new Map();
+  }
+
+  _useUidSelector(selector) {
+    // TODO: use memoize for this
+    if (!this._selectorCache.has(selector)) {
+      this._selectorCache.set(selector, selector(this._uid));
+    }
+    return this._selectorCache.get(selector)(this._store.getState());
+  }
+
+  _compareToUidSelector(value, selector) {
+    const selectorValue = this._useUidSelector(selector);
+    if (selectorValue !== value) {
+      console.error(
+        `Maki state ${value} is out of sync with tree state ${selectorValue}`
+      );
+    }
+    return value;
   }
 
   /**
@@ -62,14 +81,10 @@ class GuiObject extends MakiObject {
   }
 
   gettop() {
-    const stateTop = MakiSelectors.getTop(this._uid)(this._store.getState());
-    const makiTop = Number(this.attributes.y) || 0;
-    if (stateTop !== makiTop) {
-      console.error(
-        `Maki state ${makiTop} is out of sync with tree state ${stateTop}`
-      );
-    }
-    return makiTop;
+    return this._compareToUidSelector(
+      Number(this.attributes.y) || 0,
+      MakiSelectors.getTop
+    );
   }
 
   getleft() {


### PR DESCRIPTION
In a Redux world, most get methods will just be selectors. Selectors will be higher order functions. The outer function will take a UID (unique ID that is given to the underlying tree node) and return a memoized selector which takes a state object and returns the requested value.

Because the inner selector is memoized, we want to reuse the same inner selector across multiple calls. To achieve that, we could call the outer selector for each getter inside our constructor and stash the inner selector as a property on the instance: `_getHeightSelector`.

However, this requires doing extra work up front and could get rather tedious to type out.

Instead, I've taken the approach of creating them lazily and then storing them in a map for future use.

Additionally, I've added some helper methods to take care of the tedious work of:

* Lazily get/cache the inner selector
* Passing in the uid upon creation
* Passing in `this._store.getState()` on call
* Comparing the selector value to the Maki value (we want to do both in parallel to assert parity until we can rip out the Maki tree approach)

The result give s a really nice developer experience. Adding a new getter is just a matter of defining the selector and then wrapping the original return value in:

```
return this._compareToUidSelector(makiValue, selector);
```
This is very nice, but it is awfully abstract, and thus, probably very hard to track what's going on.