### PR TITLE
Remove script loading from initialize

### DIFF
--- a/modern/src/Actions.ts
+++ b/modern/src/Actions.ts
@@ -47,7 +47,7 @@ export function gotSkinZip(zip: JSZip, store: ModernStore) {
 
     const makiTree = await initialize(zip, xmlTree, store);
     // Execute scripts
-    await Utils.asyncTreeFlatMap(makiTree, node => {
+    await Utils.asyncTreeFlatMap(makiTree, async node => {
       switch (node.name) {
         case "groupdef": {
           // removes groupdefs from consideration (only run scripts when actually referenced by group)
@@ -63,9 +63,10 @@ export function gotSkinZip(zip: JSZip, store: ModernStore) {
             new Set(["group", "WinampAbstractionLayer", "WasabiXML"])
           );
           const system = new System(scriptGroup, store);
+          const script = await Utils.readUint8array(zip, node.attributes.file);
           run({
             runtime,
-            data: node.js_annotations.script,
+            data: script,
             system,
             log: false,
           });

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -121,10 +121,7 @@ const parsers = {
   menu: noop,
   albumart: noop,
   playlistplus: noop,
-  async script(node, parent, zip, store) {
-    const script = await Utils.readUint8array(zip, node.attributes.file);
-    return new MakiObject(node, parent, { script }, store);
-  },
+  script: noop,
 };
 
 async function parseChildren(node, children, zip, store) {


### PR DESCRIPTION
Split this out from my larger PR thats changing how we do image lookups. I'm going to be able to get rid of that extra annotations field, and this and images were the only things using it.  No reason we need to do this in the initialize step