### PR TITLE
Fix emitter export

### DIFF
--- a/modern/src/Emitter.ts
+++ b/modern/src/Emitter.ts
@@ -41,5 +41,3 @@ export default class Emitter {
     this._globalHooks = null;
   }
 }
-
-module.exports = Emitter;


### PR DESCRIPTION
Now that we `export default` at the top, we don't need this