### PR TITLE
Opacity tweak

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -152,7 +152,7 @@ function GuiObjectEvents({ node, children }) {
         return false;
       }}
       style={{
-        opacity: alpha == null ? 1 : alpha / 100,
+        opacity: alpha == null ? 1 : alpha / 255,
         pointerEvents: ghost === 1 ? "none" : null,
       }}
     >

--- a/modern/src/runtime/GuiObject.ts
+++ b/modern/src/runtime/GuiObject.ts
@@ -120,7 +120,7 @@ class GuiObject extends MakiObject {
 
   // alpha range from 0-255
   setalpha(alpha: number) {
-    this.attributes.alpha = parseInt(alpha, 10) / 255;
+    this.attributes.alpha = alpha;
     this.js_trigger("js_update");
   }
 
@@ -230,7 +230,7 @@ class GuiObject extends MakiObject {
 
   // alpha range from 0-255
   settargeta(alpha: number) {
-    this.attributes.alpha = parseInt(alpha, 10) / 255;
+    this.attributes.alpha = alpha;
     this.js_trigger("js_update");
   }
 


### PR DESCRIPTION
I was converting the alpha to what we wanted for CSS in the set methods when we should have just left it in [0-255]. Adjusted style to that range.

Left is with the tweak, right is master
![Screenshot 2019-09-04 at 15 04 44](https://user-images.githubusercontent.com/428650/64295183-85f9f000-cf25-11e9-98cf-89f9e4007719.png)
