### PR TITLE
fix ghost logic, add defaults and type conversion

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -153,7 +153,7 @@ function GuiObjectEvents({ node, children }) {
       }}
       style={{
         opacity: alpha == null ? 1 : alpha / 255,
-        pointerEvents: ghost === 1 ? "none" : null,
+        pointerEvents: ghost ? "none" : null,
       }}
     >
       {children}
@@ -329,6 +329,7 @@ function Button({
   y,
   downImage,
   tooltip,
+  ghost,
   node,
 }) {
   const [down, setDown] = React.useState(false);
@@ -373,6 +374,7 @@ function Button({
           width: Number(img.w),
           height: Number(img.h),
           backgroundImage: `url(${img.imgUrl})`,
+          pointerEvents: ghost ? "none" : null,
         }}
       >
         <XmlChildren node={node} />

--- a/modern/src/runtime/GuiObject.ts
+++ b/modern/src/runtime/GuiObject.ts
@@ -11,8 +11,29 @@ class GuiObject extends MakiObject {
   constructor(node, parent, annotations, store) {
     super(node, parent, annotations, store);
 
+    this._setAttributeDefaults(this.attributes);
+    this._convertAttributeTypes(this.attributes);
+
     this.visible = true;
     this._selectorCache = new Map();
+  }
+
+  _setAttributeDefaults(attributes) {
+    if (attributes.alpha == null) {
+      attributes.alpha = "255";
+    }
+    if (attributes.ghost == null) {
+      attributes.ghost = "0";
+    }
+  }
+
+  _convertAttributeTypes(attributes) {
+    if (attributes.alpha != null) {
+      attributes.alpha = Number(attributes.alpha);
+    }
+    if (attributes.ghost != null) {
+      attributes.ghost = !!Number(attributes.ghost);
+    }
   }
 
   _useUidSelector(selector) {


### PR DESCRIPTION
I'm not quite sure how we want to handle the types of XML attributes. 

- When we read the XML attributes all come in as strings.
- The attributes with `get`/`set` methods are typed, so it seems like we should be converting the attributes to the proper type at some point in the initialization?
- But `setxmlparam` takes a `value` that is a string. I guess we could add a type conversion there too? Not sure what the best way to handle it is

So I guess the question is when do we convert? During initialization and `setxmlparam`, or in `get`/`set` methods and anytime we directly access `attributes` like in rendering