### PR TITLE
Fix image lookups for animated layers

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -354,7 +354,7 @@ function animatedLayerOffsetAndSize(
 function AnimatedLayer({
   node,
   id,
-  image,
+  js_assets,
   x,
   y,
   w,
@@ -362,12 +362,12 @@ function AnimatedLayer({
   framewidth,
   frameheight,
 }) {
-  if (image == null) {
+  const img = js_assets.image;
+  if (img == null) {
     console.warn("Got an AnimatedLayer without an image. Rendering null", id);
     return null;
   }
 
-  const img = node.js_imageLookup(image.toLowerCase());
   const frameNum = node.getcurframe();
 
   let style = {};

--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -44,7 +44,8 @@ async function prepareMakiImage(node, zip, file) {
 function imageAttributesFromNode(node) {
   if (!node.name) return [];
   switch (node.name.toLowerCase()) {
-    case "layer": {
+    case "layer":
+    case "animatedlayer": {
       return ["image"];
     }
     case "layout": {

--- a/modern/src/runtime/AnimatedLayer.ts
+++ b/modern/src/runtime/AnimatedLayer.ts
@@ -55,7 +55,7 @@ class AnimatedLayer extends Layer {
       return;
     }
 
-    const image = this.js_imageLookup(attributes.image);
+    const image = attributes.js_assets.image;
     if (!image) {
       console.warn("Could not find image: ", attributes.image);
       return;


### PR DESCRIPTION
Animated layers were added after the `js_imageLookup` changes, so needed to fix that up