### PR TITLE
Fix for popupmenu commands

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -469,7 +469,7 @@ function Button({ makiObject }) {
 function Popupmenu({ makiObject }) {
   const { id, x, y } = makiObject.attributes;
 
-  const children = makiObject.commands.map(item => {
+  const children = makiObject.js_getCommands().map(item => {
     if (item.id === "seperator") {
       return <li />;
     }

--- a/modern/src/runtime/PopupMenu.ts
+++ b/modern/src/runtime/PopupMenu.ts
@@ -33,6 +33,10 @@ class PopupMenu extends MakiObject {
     return "PopupMenu";
   }
 
+  js_getCommands () {
+    return this._commands;
+  }
+
   addcommand(
     txt: string,
     id: number,

--- a/modern/src/runtime/PopupMenu.ts
+++ b/modern/src/runtime/PopupMenu.ts
@@ -33,7 +33,7 @@ class PopupMenu extends MakiObject {
     return "PopupMenu";
   }
 
-  js_getCommands () {
+  js_getCommands(): Command[] {
     return this._commands;
   }
 


### PR DESCRIPTION
Quick fix to get the commands of a `PopupMenu` for rendering now that they are a private property