### PR TITLE
Handle font loading breaking

### DIFF
--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -98,7 +98,12 @@ const parsers = {
     const fontBlob = await font.async("blob");
     const fontUrl = await Utils.getUrlFromBlob(fontBlob);
     const fontFamily = `font-${Utils.getId()}-${file.replace(/\./, "_")}`;
-    await Utils.loadFont(fontUrl, fontFamily);
+    try {
+      await Utils.loadFont(fontUrl, fontFamily);
+    } catch {
+      console.warn(`Failed to load font ${fontFamily}`);
+      return new MakiObject(node, parent);
+    }
     return new MakiObject(node, parent, { fontFamily });
   },
   component: (node, parent) => new WindowHolder(node, parent, undefined),


### PR DESCRIPTION
This fixes the Nebular skin which is currently breaking from font loading being angry: https://webamp.org/modern/?skinUrl=https%3A%2F%2Farchive.org%2Fcors%2Fwinampskin_Nebular%2FNebular.wal