### PR TITLE
Handle not finding font file

### DIFF
--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -95,6 +95,10 @@ const parsers = {
   truetypefont: async (node, parent, zip) => {
     const { file } = node.attributes;
     const font = Utils.getCaseInsensitveFile(zip, file);
+    if (!font) {
+      console.warn(`Unable to find font file ${file}`);
+      return new MakiObject(node, parent);
+    }
     const fontBlob = await font.async("blob");
     const fontUrl = await Utils.getUrlFromBlob(fontBlob);
     const fontFamily = `font-${Utils.getId()}-${file.replace(/\./, "_")}`;


### PR DESCRIPTION
Fix for not finding font file. Fixes: http://webamp.org/modern?skinUrl=https%3A%2F%2Farchive.org%2Fcors%2Fwinampskin_Resin%2FResin.wal

It looks like we are having trouble loading an XML file, and then not finding the font file, but in general we should guard against specifying fonts that dont exist