### PR TITLE
Fix Layer that specifies its own w/h

### DIFF
--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -282,7 +282,7 @@ function Layout({ makiObject }) {
 }
 
 function Layer({ makiObject }) {
-  const { id, js_assets, image, x, y } = makiObject.attributes;
+  const { id, js_assets, image, x, y, w, h } = makiObject.attributes;
   if (image == null) {
     console.warn("Got an Layer without an image. Rendering null", id);
     return null;
@@ -305,11 +305,19 @@ function Layer({ makiObject }) {
   if (img.y !== undefined) {
     params.backgroundPositionY = -Number(img.y);
   }
-  if (img.w !== undefined) {
-    params.width = Number(img.w);
+  if (w !== undefined || img.w !== undefined) {
+    if (w) {
+      params.width = Number(w);
+    } else {
+      params.width = Number(img.w);
+    }
   }
-  if (img.h !== undefined) {
-    params.height = Number(img.h);
+  if (h !== undefined || img.h !== undefined) {
+    if (h) {
+      params.height = Number(h);
+    } else {
+      params.height = Number(img.h);
+    }
   }
   if (img.imgUrl !== undefined) {
     params.backgroundImage = `url(${img.imgUrl}`;

--- a/modern/src/App.js
+++ b/modern/src/App.js
@@ -305,19 +305,15 @@ function Layer({ makiObject }) {
   if (img.y !== undefined) {
     params.backgroundPositionY = -Number(img.y);
   }
-  if (w !== undefined || img.w !== undefined) {
-    if (w) {
-      params.width = Number(w);
-    } else {
-      params.width = Number(img.w);
-    }
+  if (w !== undefined) {
+    params.width = Number(w);
+  } else if (img.w !== undefined) {
+    params.width = Number(img.w);
   }
-  if (h !== undefined || img.h !== undefined) {
-    if (h) {
-      params.height = Number(h);
-    } else {
-      params.height = Number(img.h);
-    }
+  if (h !== undefined) {
+    params.height = Number(h);
+  } else if (img.h !== undefined) {
+    params.height = Number(img.h);
   }
   if (img.imgUrl !== undefined) {
     params.backgroundImage = `url(${img.imgUrl}`;

--- a/modern/src/runtime/GuiObject.ts
+++ b/modern/src/runtime/GuiObject.ts
@@ -139,6 +139,12 @@ class GuiObject extends MakiObject {
     // TODO
     // I don't know how it gets calculated exactly, but if a node has a minimum
     // and maximum h, but no h, getwidth still returns a value, return min for now
+    // TODO: Need to return actual current width which can be based on underlying image
+    // CornerAmp has a calls like: obj.resize(newX, newY, obj.getwidth(), obj.getheight()),
+    // but the object has no width/height set, so it needs to return the width/height
+    // that potentially uses the image size like we do in the renderer.
+    // This is made more complicated because images depend on the current state and are
+    // potentially different attributes for different MakiObjects
     return Number(this.attributes.h) || Number(this.attributes.minimum_h) || 0;
   }
 
@@ -146,6 +152,12 @@ class GuiObject extends MakiObject {
     // TODO
     // I don't know how it gets calculated exactly, but if a node has a minimum
     // and maximum w, but no w, getwidth still returns a value, return min for now
+    // TODO: Need to return actual current width which can be based on underlying image
+    // CornerAmp has a calls like: obj.resize(newX, newY, obj.getwidth(), obj.getheight()),
+    // but the object has no width/height set, so it needs to return the width/height
+    // that potentially uses the image size like we do in the renderer.
+    // This is made more complicated because images depend on the current state and are
+    // potentially different attributes for different MakiObjects
     return Number(this.attributes.w) || Number(this.attributes.minimum_w) || 0;
   }
 


### PR DESCRIPTION
thanks @The1Freeman for pointing out a gap in between some icons on his skin that led to finding this bug.

Layer's can specify their own `w`/`h` which take precedence over the image `w`/`h`