### PR TITLE
Fix for getprivateint/string defaultvalue, check for value, not just section

### DIFF
--- a/modern/src/runtime/System.ts
+++ b/modern/src/runtime/System.ts
@@ -633,7 +633,10 @@ class System extends MakiObject {
   }
 
   getprivatestring(section: string, item: string, defvalue: string): string {
-    if (!this._privateString.has(section)) {
+    if (
+      !this._privateString.has(section) ||
+      !this._privateString.get(section).has(item)
+    ) {
       return defvalue;
     }
     // @ts-ignore We know the section exists

--- a/modern/src/runtime/System.ts
+++ b/modern/src/runtime/System.ts
@@ -119,7 +119,10 @@ class System extends MakiObject {
   }
 
   getprivateint(section: string, item: string, defvalue: number): number {
-    if (!this._privateInt.has(section)) {
+    if (
+      !this._privateInt.has(section) ||
+      !this._privateInt.get(section).has(item)
+    ) {
       return defvalue;
     }
     // @ts-ignore We know this section exists


### PR DESCRIPTION
I was looking into some stuff with private ints, and noticed we were only checking if the section existed, not if the actual value existed too.