### PR TITLE
AnimatedLayer playing default should be false

### DIFF
--- a/modern/src/runtime/AnimatedLayer.ts
+++ b/modern/src/runtime/AnimatedLayer.ts
@@ -63,7 +63,7 @@ class AnimatedLayer extends Layer {
     this._typedAttributes = this.attributes;
     const { autoplay, autoreplay, start, speed } = this._typedAttributes;
 
-    this._playing = getBoolean(autoplay, true);
+    this._playing = getBoolean(autoplay, false);
     this._autoReplay = getBoolean(autoreplay, true);
     this._frameNum = getNumber(start, 0);
     this._start = getNumber(start, 0);


### PR DESCRIPTION
I noticed a few `AnimatedLayer`s animating by default that "shouldn't" be. I would have thought that both playing/autoreplay would be false, but according to this doc, this is how it should be: http://wiki.winamp.com/wiki/XML_GUI_Objects#.3Canimatedlayer.2F.3E