### PR TITLE
Use image size in GuiObject.getwidth/getheight

### DIFF
--- a/modern/src/initialize.js
+++ b/modern/src/initialize.js
@@ -42,26 +42,6 @@ async function prepareMakiImage(node, zip, file) {
   };
 }
 
-function imageAttributesFromNode(node) {
-  if (!node.name) return [];
-  switch (node.name.toLowerCase()) {
-    case "layer":
-    case "animatedlayer": {
-      return ["image"];
-    }
-    case "layout": {
-      return ["background"];
-    }
-    case "button":
-    case "togglebutton": {
-      return ["image", "downImage"];
-    }
-    default: {
-      return [];
-    }
-  }
-}
-
 const noop = (node, parent) => new GuiObject(node, parent);
 
 const parsers = {
@@ -184,7 +164,7 @@ async function parseChildren(node, children, zip) {
 }
 
 async function nodeImageLookup(node, root, zip) {
-  const imageAttributes = imageAttributesFromNode(node);
+  const imageAttributes = Utils.imageAttributesFromNode(node);
   if (!imageAttributes || imageAttributes.length === 0) {
     return;
   }

--- a/modern/src/runtime/GuiObject.ts
+++ b/modern/src/runtime/GuiObject.ts
@@ -2,6 +2,7 @@ import MakiObject from "./MakiObject";
 import {
   findDescendantByTypeAndId,
   findParentNodeOfType,
+  baseImageAttributeFromObject,
   unimplementedWarning,
 } from "../utils";
 import { ModernStore, XmlNode } from "../types";
@@ -140,29 +141,41 @@ class GuiObject extends MakiObject {
   }
 
   getheight(): number {
-    // TODO
-    // I don't know how it gets calculated exactly, but if a node has a minimum
-    // and maximum h, but no h, getwidth still returns a value, return min for now
-    // TODO: Need to return actual current width which can be based on underlying image
-    // CornerAmp has a calls like: obj.resize(newX, newY, obj.getwidth(), obj.getheight()),
-    // but the object has no width/height set, so it needs to return the width/height
-    // that potentially uses the image size like we do in the renderer.
-    // This is made more complicated because images depend on the current state and are
-    // potentially different attributes for different MakiObjects
-    return Number(this.attributes.h) || Number(this.attributes.minimum_h) || 0;
+    if (this.attributes.h !== undefined) {
+      return Number(this.attributes.h);
+    } else {
+      const baseImage = baseImageAttributeFromObject(this);
+      if (baseImage) {
+        // TODO: fix the type on this, we currently have better typing for this in
+        // AnimatedLayer where we convert to _typedAttributes, as we apply that new
+        // standard up to GuiObject/MakiObject we should be able to remove the ignore
+        // @ts-ignore
+        const image = this.attributes.js_assets[baseImage];
+        if (image && image.h !== undefined) {
+          return image.h;
+        }
+      }
+    }
+    return 0;
   }
 
   getwidth(): number {
-    // TODO
-    // I don't know how it gets calculated exactly, but if a node has a minimum
-    // and maximum w, but no w, getwidth still returns a value, return min for now
-    // TODO: Need to return actual current width which can be based on underlying image
-    // CornerAmp has a calls like: obj.resize(newX, newY, obj.getwidth(), obj.getheight()),
-    // but the object has no width/height set, so it needs to return the width/height
-    // that potentially uses the image size like we do in the renderer.
-    // This is made more complicated because images depend on the current state and are
-    // potentially different attributes for different MakiObjects
-    return Number(this.attributes.w) || Number(this.attributes.minimum_w) || 0;
+    if (this.attributes.w !== undefined) {
+      return Number(this.attributes.w);
+    } else {
+      const baseImage = baseImageAttributeFromObject(this);
+      if (baseImage) {
+        // TODO: fix the type on this, we currently have better typing for this in
+        // AnimatedLayer where we convert to _typedAttributes, as we apply that new
+        // standard up to GuiObject/MakiObject we should be able to remove the ignore
+        // @ts-ignore
+        const image = this.attributes.js_assets[baseImage];
+        if (image && image.w !== undefined) {
+          return image.w;
+        }
+      }
+    }
+    return 0;
   }
 
   resize(x: number, y: number, w: number, h: number): void {

--- a/modern/src/utils.ts
+++ b/modern/src/utils.ts
@@ -2,6 +2,7 @@ import JSZip from "jszip";
 import { xml2js } from "xml-js";
 import { XmlNode } from "./types";
 import MakiObject from "./runtime/MakiObject";
+import GuiObject from "./runtime/GuiObject";
 
 let nextId = 0;
 export function getId(): number {
@@ -414,4 +415,43 @@ if (typeof document !== "undefined") {
 
 export function getMousePosition() {
   return mousePosition;
+}
+
+export function imageAttributesFromNode(node: XmlNode): Array<string> {
+  if (!node.name) return [];
+  switch (node.name.toLowerCase()) {
+    case "layer":
+    case "animatedlayer": {
+      return ["image"];
+    }
+    case "layout": {
+      return ["background"];
+    }
+    case "button":
+    case "togglebutton": {
+      return ["image", "downImage"];
+    }
+    default: {
+      return [];
+    }
+  }
+}
+
+export function baseImageAttributeFromObject(obj: GuiObject): string | null {
+  switch (obj.getclassname()) {
+    case "Layer":
+    case "AnimatedLayer": {
+      return "image";
+    }
+    case "Layout": {
+      return "background";
+    }
+    case "Button":
+    case "ToggleButton": {
+      return "image";
+    }
+    default: {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
I had wanted to use `getwidth`/`getheight` in the rendering too, but ran into a snag. The renderer needs to know when we don't actually have a width/height specified and not use any, but `getwidth`/`getheight` always return a number