### PR TITLE
Include documentation about start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ I do most development by starting the demo site in dev mode and iterating that w
     # Clone the repo
     cd webamp
     # __Note:__ Please use yarn over npm, since yarn will respect our `yarn.lock` file
-    yarn
+    yarn install
+    yarn start
 
 `http://localhost:8080/` should automatically open in your browser.
 


### PR DESCRIPTION
I've got stuck for some minutes before I could run the hot reload server locally. That's because the docs actually include instructions about the build but not the local development server. Had to look `package.json` to figure it out.

- Include `yarn start` to local development instructions
- Use `yarn install` instead of `yarn` just to make the intentions explicit