### PR TITLE
Use default cursor for context menu

### DIFF
--- a/packages/webamp/css/context-menu.css
+++ b/packages/webamp/css/context-menu.css
@@ -3,6 +3,7 @@
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
+  cursor: default;
 }
 
 #webamp-context-menu .context-menu.bottom {


### PR DESCRIPTION
Currently the cursor over a context menu shows up as an "I-beam" text cursor. This PR changes it to be an arrow/default cursor.