### PR TITLE
README: Fix WebVS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Join our community chat on Discord: <https://discord.gg/fBTDMqR>
 There are a few related projects that have communites:
 
 - [Winamp Community Update Pack] - "New plug-ins to add additional features to Winamp as well as replacement plug-ins to provide better implementations of some of the plug-ins natively included with Winamp". ([Forum](https://getwacup.com/community/) / [Discord server](https://discord.gg/5pVTdbj))
-- [Webvs](https://gitter.im/visbot/AVS) -
+- [Webvs](https://github.com/azeem/webvs) -
   A Winamp AVS like visualization library for the web. ([Gitter chat](https://gitter.im/visbot/AVS))
 
 ## In the Wild


### PR DESCRIPTION
Somehow the Gitter chat link ended up in there twice.