### PR TITLE
Render visualizer background for screenshot

### DIFF
--- a/packages/webamp/js/components/Visualizer.tsx
+++ b/packages/webamp/js/components/Visualizer.tsx
@@ -91,6 +91,7 @@ function Visualizer({ analyser }: Props) {
         return;
       }
       if (dummyVizData) {
+        canvasCtx.drawImage(bgCanvas, 0, 0);
         Object.entries(dummyVizData).forEach(([i, value]) => {
           paintBar(canvasCtx, Number(i), value, -1);
         });


### PR DESCRIPTION
This renders the visualizer's background grid when rendering the dummy visualizer data used for screenshots.

## Before

<img width="293" alt="Screen Shot 2020-09-29 at 7 28 38 PM" src="https://user-images.githubusercontent.com/162735/94636512-fb9bd100-0289-11eb-95aa-72fa6519601b.png">

https://webamp.org/?screenshot=1&skinUrl=https://cdn.webampskins.org/skins/6720179b1634c8bcc08dd043a0b65ae7.wsz

## After

<img width="289" alt="Screen Shot 2020-09-29 at 7 29 01 PM" src="https://user-images.githubusercontent.com/162735/94636529-09e9ed00-028a-11eb-8e72-a3c7bb56bf06.png">

https://5f73ec8cce00bb0008b9cda7--ecstatic-poincare-fe4c13.netlify.app/?screenshot=1&skinUrl=https://cdn.webampskins.org/skins/6720179b1634c8bcc08dd043a0b65ae7.wsz
