### PR TITLE
Pull demo site webamp config into typed module

### DIFF
--- a/packages/webamp/demo/config/webpack.common.js
+++ b/packages/webamp/demo/config/webpack.common.js
@@ -76,7 +76,7 @@ module.exports = {
     maxAssetSize: 7000000,
   },
   entry: {
-    webamp: ["./js/index.js"],
+    webamp: ["./js/index.tsx"],
   },
   context: path.resolve(__dirname, "../"),
   output: {

--- a/packages/webamp/demo/js/Webamp.ts
+++ b/packages/webamp/demo/js/Webamp.ts
@@ -4,7 +4,12 @@
 // away once we've figured out how to expose all the things that the demo site
 // needs, or reduce the things that the demo site needs access to.
 
-export { default as WebampLazy } from "../../js/webampLazy";
+export {
+  default as WebampLazy,
+  Options,
+  PrivateOptions,
+  WindowLayout,
+} from "../../js/webampLazy";
 export {
   ButterchurnOptions,
   Track,

--- a/packages/webamp/demo/js/config.ts
+++ b/packages/webamp/demo/js/config.ts
@@ -33,7 +33,7 @@ if ("URLSearchParams" in window) {
   // SHOW_DESKTOP_ICONS = Boolean(params.get("icons"));
 }
 
-export const skinUrl = config.skinUrl === undefined ? null : config.skinUrl;
+export const skinUrl = config.skinUrl ?? null;
 
 // https://freemusicarchive.org/music/netBloc_Artists/netBloc_Vol_24_tiuqottigeloot/
 const album = "netBloc Vol. 24: tiuqottigeloot";

--- a/packages/webamp/demo/js/webampConfig.ts
+++ b/packages/webamp/demo/js/webampConfig.ts
@@ -1,0 +1,134 @@
+import * as Sentry from "@sentry/browser";
+// @ts-ignore
+import createMiddleware from "redux-sentry-middleware";
+// @ts-ignore
+import isButterchurnSupported from "butterchurn/lib/isSupported.min";
+import { loggerMiddleware } from "./eventLogger";
+
+import {
+  Action,
+  Options,
+  PrivateOptions,
+  WINDOWS,
+  STEP_MARQUEE,
+  UPDATE_TIME_ELAPSED,
+  UPDATE_WINDOW_POSITIONS,
+  SET_VOLUME,
+  SET_BALANCE,
+  SET_BAND_VALUE,
+  AppState,
+  WindowLayout,
+} from "./Webamp";
+
+import { getButterchurnOptions } from "./butterchurnOptions";
+import dropboxFilePicker from "./dropboxFilePicker";
+import availableSkins from "./avaliableSkins";
+
+import { initialTracks, initialState } from "./config";
+import screenshotInitialState from "./screenshotInitialState";
+
+const NOISY_ACTION_TYPES = new Set([
+  STEP_MARQUEE,
+  UPDATE_TIME_ELAPSED,
+  UPDATE_WINDOW_POSITIONS,
+  SET_VOLUME,
+  SET_BALANCE,
+  SET_BAND_VALUE,
+]);
+
+const MIN_MILKDROP_WIDTH = 725;
+
+let lastActionType: string | null = null;
+
+// Filter out consecutive common actions
+function filterBreadcrumbActions(action: Action) {
+  const noisy =
+    lastActionType != null &&
+    NOISY_ACTION_TYPES.has(action.type) &&
+    NOISY_ACTION_TYPES.has(lastActionType);
+  lastActionType = action.type;
+  return !noisy;
+}
+
+const sentryMiddleware = createMiddleware(Sentry, {
+  filterBreadcrumbActions,
+  stateTransformer: getDebugData,
+});
+
+export function getWebampConfig(
+  screenshot: boolean,
+  skinUrl: string | null
+): Options & PrivateOptions {
+  let __butterchurnOptions;
+  let __initialWindowLayout: WindowLayout | undefined;
+  if (isButterchurnSupported()) {
+    const startWithMilkdropHidden =
+      document.body.clientWidth < MIN_MILKDROP_WIDTH ||
+      skinUrl != null ||
+      screenshot;
+
+    __butterchurnOptions = getButterchurnOptions(startWithMilkdropHidden);
+
+    if (startWithMilkdropHidden) {
+      __initialWindowLayout = {
+        [WINDOWS.MAIN]: { position: { x: 0, y: 0 } },
+        [WINDOWS.EQUALIZER]: { position: { x: 0, y: 116 } },
+        [WINDOWS.PLAYLIST]: { position: { x: 0, y: 232 }, size: [0, 0] },
+        [WINDOWS.MILKDROP]: { position: { x: 0, y: 348 }, size: [0, 0] },
+      };
+    } else {
+      __initialWindowLayout = {
+        [WINDOWS.MAIN]: { position: { x: 0, y: 0 } },
+        [WINDOWS.EQUALIZER]: { position: { x: 0, y: 116 } },
+        [WINDOWS.PLAYLIST]: { position: { x: 0, y: 232 }, size: [0, 4] },
+        [WINDOWS.MILKDROP]: { position: { x: 275, y: 0 }, size: [7, 12] },
+      };
+    }
+  }
+
+  const initialSkin = !skinUrl ? undefined : { url: skinUrl };
+
+  return {
+    initialSkin,
+    initialTracks: screenshot ? undefined : initialTracks,
+    availableSkins,
+    filePickers: [dropboxFilePicker],
+    enableHotkeys: true,
+    handleTrackDropEvent: (e) => {
+      const trackJson = e.dataTransfer.getData("text/json");
+      if (trackJson == null) {
+        return null;
+      }
+      try {
+        const track = JSON.parse(trackJson);
+        return [track];
+      } catch (err) {
+        return null;
+      }
+    },
+    requireJSZip: () =>
+      // @ts-ignore
+      import(/* webpackChunkName: "jszip" */ "jszip/dist/jszip"),
+    requireMusicMetadata: () =>
+      import(
+        /* webpackChunkName: "music-metadata-browser" */ "music-metadata-browser/dist/index"
+      ),
+    __initialWindowLayout,
+    __initialState: screenshot ? screenshotInitialState : initialState,
+    __butterchurnOptions,
+    __customMiddlewares: [sentryMiddleware, loggerMiddleware],
+  };
+}
+
+function getDebugData(state: AppState) {
+  return {
+    ...state,
+    display: {
+      ...state.display,
+      skinGenLetterWidths: "[[REDACTED]]",
+      skinImages: "[[REDACTED]]",
+      skinCursors: "[[REDACTED]]",
+      skinRegion: "[[REDACTED]]",
+    },
+  };
+}

--- a/packages/webamp/js/types.ts
+++ b/packages/webamp/js/types.ts
@@ -705,7 +705,7 @@ export interface IMusicMetadataBrowserApi {
 }
 
 export interface Extras {
-  requireJSZip(): Promise<never>;
+  requireJSZip(): Promise<any>;
   requireMusicMetadata(): Promise<IMusicMetadataBrowserApi>;
   convertPreset: ((file: File) => Promise<Object>) | null;
   handleTrackDropEvent?: (

--- a/packages/webamp/js/types.ts
+++ b/packages/webamp/js/types.ts
@@ -360,7 +360,7 @@ export type Action =
     }
   | {
       type: "SET_DUMMY_VIZ_DATA";
-      data: null;
+      data: DummyVizData;
     }
   | {
       type: "SET_BAND_VALUE";

--- a/packages/webamp/js/webampLazy.tsx
+++ b/packages/webamp/js/webampLazy.tsx
@@ -39,8 +39,9 @@ import Emitter from "./emitter";
 import "../css/base-skin.css";
 import { SerializedStateV1 } from "./serializedStates/v1Types";
 import Disposable from "./Disposable";
+import { DeepPartial } from "redux";
 
-interface Options {
+export interface Options {
   /**
    * An object representing the initial skin to use.
    *
@@ -113,21 +114,23 @@ interface Options {
   handleSaveListEvent?: (tracks: Track[]) => null | Promise<null>;
 }
 
-interface PrivateOptions {
-  avaliableSkins?: { url: string; name: string }[]; // Old misspelled name
-  requireJSZip(): Promise<never>; // TODO: Type JSZip
-  requireMusicMetadata(): Promise<any>; // TODO: Type musicmetadata
-  __initialState?: AppState;
-  __customMiddlewares?: Middleware[];
-  __initialWindowLayout: {
-    [windowId: string]: {
-      size: null | [number, number];
-      position: WindowPosition;
-    };
+export type WindowLayout = {
+  [windowId: string]: {
+    size?: null | [number, number];
+    position: WindowPosition;
   };
-  __butterchurnOptions: ButterchurnOptions;
+};
+
+export interface PrivateOptions {
+  avaliableSkins?: { url: string; name: string }[]; // Old misspelled name
+  requireJSZip(): Promise<any>; // TODO: Type JSZip
+  requireMusicMetadata(): Promise<any>; // TODO: Type musicmetadata
+  __initialState?: DeepPartial<AppState>;
+  __customMiddlewares?: Middleware[];
+  __initialWindowLayout?: WindowLayout;
+  __butterchurnOptions?: ButterchurnOptions;
   // This is used by https://winampify.io/ to proxy through to Spotify's API.
-  __customMediaClass: typeof Media; // This should have the same interface as Media
+  __customMediaClass?: typeof Media; // This should have the same interface as Media
 }
 
 // Return a promise that resolves when the store matches a predicate.


### PR DESCRIPTION
Before we can make the demo site consume the actual NPM module, we need to have the NPM module export all the things that the demo site needs. This includes a lot of types for private config options. Moving the code that passes in the config options into a typed module will help with this.