### PR TITLE
Upgrade Butterchurn

### DIFF
--- a/packages/webamp/demo/js/butterchurnOptions.ts
+++ b/packages/webamp/demo/js/butterchurnOptions.ts
@@ -89,9 +89,17 @@ export function getButterchurnOptions(
           throw new Error("We still need to implement this");
         }
       }
-      // TODO: Fallback to some other presets?
-      return loadButterchurnPresetMapURL(
-        "https://unpkg.com/butterchurn-presets-weekly@0.0.2/weeks/week1/presets.json"
+
+      const presets = await import(
+        // @ts-ignore
+        "butterchurn-presets/lib/butterchurnPresetsMinimal.min"
+      );
+      return Object.entries(presets.default.getPresets()).map(
+        ([name, preset]) => {
+          const butterchurnPresetObject: any = preset;
+          butterchurnPresetObject.useWASM = true;
+          return { name, butterchurnPresetObject };
+        }
       );
     },
     butterchurnOpen: !startWithMilkdropHidden,

--- a/packages/webamp/demo/js/butterchurnOptions.ts
+++ b/packages/webamp/demo/js/butterchurnOptions.ts
@@ -95,11 +95,9 @@ export function getButterchurnOptions(
         // @ts-ignore
         "butterchurn-presets/lib/butterchurnPresetsMinimal.min"
       );
-      return Object.entries(presets.default.getPresets()).map(
-        ([name, preset]) => {
-          return { name, butterchurnPresetObject: preset as Object };
-        }
-      );
+      return Object.entries(presets.default).map(([name, preset]) => {
+        return { name, butterchurnPresetObject: preset as Object };
+      });
     },
     butterchurnOpen: !startWithMilkdropHidden,
   };

--- a/packages/webamp/demo/js/butterchurnOptions.ts
+++ b/packages/webamp/demo/js/butterchurnOptions.ts
@@ -34,7 +34,7 @@ export function getButterchurnOptions(
   return {
     importButterchurn: () => {
       return import(
-        /* webpackChunkName: "butterchurn-initial-dependencies" */
+        /* webpackChunkName: "butterchurn" */
         // @ts-ignore
         "butterchurn"
       );
@@ -91,14 +91,13 @@ export function getButterchurnOptions(
       }
 
       const presets = await import(
+        /* webpackChunkName: "butterchurn-presets" */
         // @ts-ignore
         "butterchurn-presets/lib/butterchurnPresetsMinimal.min"
       );
       return Object.entries(presets.default.getPresets()).map(
         ([name, preset]) => {
-          const butterchurnPresetObject: any = preset;
-          butterchurnPresetObject.useWASM = true;
-          return { name, butterchurnPresetObject };
+          return { name, butterchurnPresetObject: preset as Object };
         }
       );
     },

--- a/packages/webamp/demo/js/butterchurnOptions.ts
+++ b/packages/webamp/demo/js/butterchurnOptions.ts
@@ -97,7 +97,7 @@ export function getButterchurnOptions(
       const presets = await import(
         /* webpackChunkName: "butterchurn-presets" */
         // @ts-ignore
-        "butterchurn-presets/lib/butterchurnPresetsMinimal.min"
+        "butterchurn-presets/src/minimal.js"
       );
       return Object.entries(presets.default).map(([name, preset]) => {
         return { name, butterchurnPresetObject: addUseWASM(preset as Object) };

--- a/packages/webamp/demo/js/butterchurnOptions.ts
+++ b/packages/webamp/demo/js/butterchurnOptions.ts
@@ -1,5 +1,9 @@
 import { ButterchurnOptions } from "./Webamp";
 
+function addUseWASM(obj: Object): Object {
+  return { ...obj, useWASM: true };
+}
+
 const KNOWN_PRESET_URLS_REGEXES = [
   /^https:\/\/unpkg\.com\/butterchurn-presets\/.*\.json$/,
   /^https:\/\/unpkg\.com\/butterchurn-presets-weekly\/.*\.json$/,
@@ -96,7 +100,7 @@ export function getButterchurnOptions(
         "butterchurn-presets/lib/butterchurnPresetsMinimal.min"
       );
       return Object.entries(presets.default).map(([name, preset]) => {
-        return { name, butterchurnPresetObject: preset as Object };
+        return { name, butterchurnPresetObject: addUseWASM(preset as Object) };
       });
     },
     butterchurnOpen: !startWithMilkdropHidden,

--- a/packages/webamp/js/actionCreators/milkdrop.ts
+++ b/packages/webamp/js/actionCreators/milkdrop.ts
@@ -19,19 +19,26 @@ import {
 } from "../types";
 import * as FileUtils from "../fileUtils";
 
+function addUseWASM(obj: Object): Object {
+  return { ...obj, useWASM: true };
+}
+
 function normalizePresetTypes(preset: Preset): StatePreset {
   const { name } = preset;
   if ("butterchurnPresetObject" in preset) {
     return {
       type: "RESOLVED",
       name,
-      preset: preset.butterchurnPresetObject,
+      preset: addUseWASM(preset.butterchurnPresetObject),
     };
   } else if ("getButterchrunPresetObject" in preset) {
     return {
       type: "UNRESOLVED",
       name,
-      getPreset: preset.getButterchrunPresetObject,
+      getPreset: async () => {
+        const json = await preset.getButterchrunPresetObject();
+        return addUseWASM(json);
+      },
     };
   } else if ("butterchurnPresetUrl" in preset) {
     return {
@@ -39,7 +46,8 @@ function normalizePresetTypes(preset: Preset): StatePreset {
       name,
       getPreset: async () => {
         const resp = await fetch(preset.butterchurnPresetUrl);
-        return resp.json();
+        const json = await resp.json();
+        return addUseWASM(json);
       },
     };
   }

--- a/packages/webamp/js/actionCreators/milkdrop.ts
+++ b/packages/webamp/js/actionCreators/milkdrop.ts
@@ -19,26 +19,19 @@ import {
 } from "../types";
 import * as FileUtils from "../fileUtils";
 
-function addUseWASM(obj: Object): Object {
-  return { ...obj, useWASM: true };
-}
-
 function normalizePresetTypes(preset: Preset): StatePreset {
   const { name } = preset;
   if ("butterchurnPresetObject" in preset) {
     return {
       type: "RESOLVED",
       name,
-      preset: addUseWASM(preset.butterchurnPresetObject),
+      preset: preset.butterchurnPresetObject,
     };
   } else if ("getButterchrunPresetObject" in preset) {
     return {
       type: "UNRESOLVED",
       name,
-      getPreset: async () => {
-        const json = await preset.getButterchrunPresetObject();
-        return addUseWASM(json);
-      },
+      getPreset: preset.getButterchrunPresetObject,
     };
   } else if ("butterchurnPresetUrl" in preset) {
     return {
@@ -46,8 +39,7 @@ function normalizePresetTypes(preset: Preset): StatePreset {
       name,
       getPreset: async () => {
         const resp = await fetch(preset.butterchurnPresetUrl);
-        const json = await resp.json();
-        return addUseWASM(json);
+        return resp.json();
       },
     };
   }

--- a/packages/webamp/package.json
+++ b/packages/webamp/package.json
@@ -135,7 +135,8 @@
   },
   "dependencies": {
     "ani-cursor": "^0.0.4",
-    "butterchurn": "^2.6.7",
+    "butterchurn": "^3.0.0-beta.0",
+    "butterchurn-presets": "^3.0.0-beta.0",
     "classnames": "^2.2.5",
     "fscreen": "^1.0.2",
     "invariant": "^2.2.3",

--- a/packages/webamp/package.json
+++ b/packages/webamp/package.json
@@ -136,7 +136,7 @@
   "dependencies": {
     "ani-cursor": "^0.0.4",
     "butterchurn": "^3.0.0-beta.1",
-    "butterchurn-presets": "^3.0.0-beta.0",
+    "butterchurn-presets": "3.0.0-beta.1",
     "classnames": "^2.2.5",
     "fscreen": "^1.0.2",
     "invariant": "^2.2.3",

--- a/packages/webamp/package.json
+++ b/packages/webamp/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "ani-cursor": "^0.0.4",
-    "butterchurn": "^3.0.0-beta.0",
+    "butterchurn": "^3.0.0-beta.1",
     "butterchurn-presets": "^3.0.0-beta.0",
     "classnames": "^2.2.5",
     "fscreen": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,11 @@
     "@algolia/logger-common" "4.3.0"
     "@algolia/requester-common" "4.3.0"
 
+"@assemblyscript/loader@^0.17.11":
+  version "0.17.14"
+  resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.17.14.tgz#43bfe793c787180c5eb0a57ada8318fb62171b4e"
+  integrity sha512-+PVTOfla/0XMLRTQLJFPg4u40XcdTfon6GGea70hBGi8Pd7ZymIXyVUR+vK8wt5Jb4MVKTKPIz43Myyebw5mZA==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -1794,6 +1799,13 @@
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -4269,12 +4281,29 @@ busboy@^0.3.1:
   dependencies:
     dicer "0.3.0"
 
+butterchurn-presets@^3.0.0-beta.0:
+  version "3.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-3.0.0-beta.0.tgz#a2b44d6164256ebacd5f779803d35aa6ab630330"
+  integrity sha512-IBfF7gdjM513pfA7LIBue7GzW074zKzf1NGpros5RvXvDxe+S5KEbhZxgBxXHp8xlQA3eDbD5aEt0SPxB2HWnQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 butterchurn@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/butterchurn/-/butterchurn-2.6.7.tgz#1ff0c1365731a4fb7ada7bb16ae1c6f09a110c12"
   dependencies:
     "@babel/runtime" "^7.0.0"
     ecma-proposal-math-extensions "0.0.2"
+
+butterchurn@^3.0.0-beta.0:
+  version "3.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/butterchurn/-/butterchurn-3.0.0-beta.0.tgz#c70ff83ef39b3d27232ddca64fd187f56cd05adf"
+  integrity sha512-fFOUSzXVB5yXQRCrUXlBmUSGfB8heJVlRrmJQXumdzUr76aUIjt7hSVuYqa00Efv4JWn6QZqD8PDdypJfAbbeQ==
+  dependencies:
+    "@assemblyscript/loader" "^0.17.11"
+    "@babel/runtime" "^7.11.2"
+    ecma-proposal-math-extensions "0.0.2"
+    eel-wasm "^0.0.12"
 
 byte-data@18.1.1, byte-data@^18.0.3:
   version "18.1.1"
@@ -5771,6 +5800,11 @@ ecstatic@^3.0.0:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+eel-wasm@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/eel-wasm/-/eel-wasm-0.0.12.tgz#7bec69b6d7e1573cc1fc4d4ad65e92713dee79e1"
+  integrity sha512-FgC/P8j6b9hwMzerko+ixrdeWKN/kFR15FPNWUZ/ngtsMK84sD479385ccTywyAR47jegXompUGpqbWTGn7kIw==
 
 ejs@^2.6.1:
   version "2.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4295,10 +4295,10 @@ butterchurn@^2.6.7:
     "@babel/runtime" "^7.0.0"
     ecma-proposal-math-extensions "0.0.2"
 
-butterchurn@^3.0.0-beta.0:
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/butterchurn/-/butterchurn-3.0.0-beta.0.tgz#c70ff83ef39b3d27232ddca64fd187f56cd05adf"
-  integrity sha512-fFOUSzXVB5yXQRCrUXlBmUSGfB8heJVlRrmJQXumdzUr76aUIjt7hSVuYqa00Efv4JWn6QZqD8PDdypJfAbbeQ==
+butterchurn@^3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/butterchurn/-/butterchurn-3.0.0-beta.1.tgz#b7e5b1a2168ce041a2a0b1771b23d958002b331e"
+  integrity sha512-crY/ppARjwHR6f6PcSIjvDgm1OrzTHdJa9ubAPZzOSsp/ohEanCIn1xhrUOSFT4c7rRKL7c3yqANICZMQAOh2w==
   dependencies:
     "@assemblyscript/loader" "^0.17.11"
     "@babel/runtime" "^7.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,10 +4281,10 @@ busboy@^0.3.1:
   dependencies:
     dicer "0.3.0"
 
-butterchurn-presets@^3.0.0-beta.0:
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-3.0.0-beta.0.tgz#a2b44d6164256ebacd5f779803d35aa6ab630330"
-  integrity sha512-IBfF7gdjM513pfA7LIBue7GzW074zKzf1NGpros5RvXvDxe+S5KEbhZxgBxXHp8xlQA3eDbD5aEt0SPxB2HWnQ==
+butterchurn-presets@3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/butterchurn-presets/-/butterchurn-presets-3.0.0-beta.1.tgz#8f2474f7857c7a6494476dec56dbd4255e1f4b0a"
+  integrity sha512-2/rBysBUNVdQviwQWDqEM+NtiAF55HwCHrPVmy65wh/ruGyUYuPZpp/pNUCyCsQAdajfPVcjViqkNBThdzHhDA==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
Work in progress diff exploring what it will take to adopt the new Wasm version of Butterchurn.

## Required to Ship

- [ ] ~~All archive.org files updated to include EEL (@jberg)~~
- [ ] ~~All S3 files updated to include EEL (@jberg)~~
- [x] ~~If Butterchurn exposes a way to enforce `useWASM` we should update to that **or**~~ ensure all the ways that we load presets set `useWASM` on the preset.