### PR TITLE
1000+ kbps

### DIFF
--- a/packages/webamp/js/components/MainWindow/Kbps.tsx
+++ b/packages/webamp/js/components/MainWindow/Kbps.tsx
@@ -5,7 +5,10 @@ import * as Selectors from "../../selectors";
 import { useTypedSelector } from "../../hooks";
 
 const Kbps = memo(() => {
-  const kbps = useTypedSelector(Selectors.getKbps);
+  let kbps = useTypedSelector(Selectors.getKbps)?.padStart(3);
+  if (kbps !== undefined && kbps?.length > 3) {
+    kbps = kbps.substring(0, 2) + "H";
+  }
   return (
     <div id="kbps">
       <CharacterString>{kbps || ""}</CharacterString>


### PR DESCRIPTION
When bitrate exceeds 1000 kbps, Winamp shows "10H", and will increment "11H" etc. as needed. Usually happens with FLAC files.

For bitrates less than 100, there is leading space.