### PR TITLE
Enable Butterchurn even on mobile

### DIFF
--- a/packages/webamp/demo/js/webampConfig.ts
+++ b/packages/webamp/demo/js/webampConfig.ts
@@ -64,14 +64,14 @@ export async function getWebampConfig(
   let __butterchurnOptions;
   let __initialWindowLayout: WindowLayout | undefined;
   if (isButterchurnSupported()) {
-    const startWithMilkdropHidden =
-      document.body.clientWidth < MIN_MILKDROP_WIDTH ||
-      skinUrl != null ||
-      screenshot;
+    const startWithMilkdropHidden = skinUrl != null || screenshot;
 
     __butterchurnOptions = getButterchurnOptions(startWithMilkdropHidden);
 
-    if (startWithMilkdropHidden) {
+    if (
+      startWithMilkdropHidden ||
+      document.body.clientWidth < MIN_MILKDROP_WIDTH
+    ) {
       __initialWindowLayout = {
         [WINDOWS.MAIN]: { position: { x: 0, y: 0 } },
         [WINDOWS.EQUALIZER]: { position: { x: 0, y: 116 } },


### PR DESCRIPTION
The next version of Safari will support WebGL 2 and thus Butterchurn. Having played with it a bit more, I think I'm convinced that it should be enabled by default.

This makes it so that if your browser supports Butterchurn, we'll show the window by default even if you are on mobile. So that means Android, and up-to-date iOS.

We still hide Butterchurn for screenshot tests and when loading a skin, since many skins don't include sprites for the Milkdrop window.