### PR TITLE
Corrected documentation pertaining to integertotime

### DIFF
--- a/packages/webamp-modern-2/src/skin/SystemObject.ts
+++ b/packages/webamp-modern-2/src/skin/SystemObject.ts
@@ -197,14 +197,15 @@ export default class SystemObject extends BaseObject {
   }
 
   /**
-   * Convert a time in seconds to a MM:SS value.
-   *
-   * @ret       The string representation of the time (MM:SS).
+   * Convert a time in seconds to a M:SS value, does not
+   * return MM:SS as originally stated.
+   * 
+   * @ret       The string representation of the time (M:SS).
    * @param  value Timestamp to use.
    */
   integertotime(value: number): string {
     // TODO
-    return "00:00";
+    return "0:00";
   }
 
   /**

--- a/packages/webamp-modern-2/src/skin/Text.ts
+++ b/packages/webamp-modern-2/src/skin/Text.ts
@@ -100,9 +100,9 @@ offsety - (int) Extra pixels to be added to or subtracted from the calculated x 
         case "vid_info":
           return "vid_info";
         case "time":
-          return "01:58";
+          return "1:58";
         case "songlength":
-          return "05:58";
+          return "5:58";
         case "songname":
           return "Niente da Caprie (3";
         case "songinfo":


### PR DESCRIPTION
Fixed the dummy strings which were wrongly returning MM:SS, when in reality it's M:SS