### PR TITLE
correction gamma colors

### DIFF
--- a/packages/webamp-modern-2/src/skin/GammaGroup.ts
+++ b/packages/webamp-modern-2/src/skin/GammaGroup.ts
@@ -69,10 +69,12 @@ export default class GammaGroup {
         data[i + 2] = (data[i + 2] >> 1, 0, 255); // blue
       }
       let [ir,ig,ib] = [data[i],data[i+1],data[i+2] ];
-      if(this._gray==2)  ir = (ir + ig + ib)/3;
-      if(this._gray==1)  ir = Math.max(ir,ig,ib);
-      ig = ir;
-      ib = ir;
+      if(this._gray != 0){
+        if(this._gray==2)  ir = (ir + ig + ib)/3;
+        if(this._gray==1)  ir = Math.max(ir,ig,ib);
+        ig = ir;
+        ib = ir;
+      }
       data[i] =     clamp(ir * r, 0, 255); // red
       data[i + 1] = clamp(ig * g, 0, 255); // green
       data[i + 2] = clamp(ib * b, 0, 255); // blue

--- a/packages/webamp-modern-2/src/skin/GammaGroup.ts
+++ b/packages/webamp-modern-2/src/skin/GammaGroup.ts
@@ -53,7 +53,7 @@ export default class GammaGroup {
       return glTransformImage(img);
     }
     const [r, g, b] = this._value.split(",").map((v) => {
-      return (Number(v) / 4096) * 255;
+      return (Number(v) / 4096) +1.0;
     });
     const canvas = document.createElement("canvas");
     canvas.width = img.width;
@@ -68,10 +68,14 @@ export default class GammaGroup {
         data[i + 1] = (data[i + 1] >> 1, 0, 255); // green
         data[i + 2] = (data[i + 2] >> 1, 0, 255); // blue
       }
-
-      data[i] = clamp(data[i] + r, 0, 255); // red
-      data[i + 1] = clamp(data[i + 1] + g, 0, 255); // green
-      data[i + 2] = clamp(data[i + 2] + b, 0, 255); // blue
+      let [ir,ig,ib] = [data[i],data[i+1],data[i+2] ];
+      if(this._gray==2)  ir = (ir + ig + ib)/3;
+      if(this._gray==1)  ir = Math.max(ir,ig,ib);
+      ig = ir;
+      ib = ir;
+      data[i] =     clamp(ir * r, 0, 255); // red
+      data[i + 1] = clamp(ig * g, 0, 255); // green
+      data[i + 2] = clamp(ib * b, 0, 255); // blue
     }
     ctx.putImageData(imageData, 0, 0);
     return canvas.toDataURL();


### PR DESCRIPTION
current webamp gamma color calculation resulting a too bright / too dark picture.
we found that `int c = -((1-(required/source))*4096);` [1]
in which similar to `required_color = ((source * c) + (source*4096)) / 4096;` 
Visually, it generating a very similar appearance to winamp modern skin.


![comparing-the-3](https://user-images.githubusercontent.com/1678529/155955568-57ef19bf-5056-4d8a-a78d-cc3103b593e8.png)
[1] /Plugins/freeform/wacs/coloreditor/xml/ce_extend.m