### PR TITLE
Allow a single mouse drag across the EQ to set all values

### DIFF
--- a/packages/webamp/js/components/ClickedDiv.tsx
+++ b/packages/webamp/js/components/ClickedDiv.tsx
@@ -4,7 +4,7 @@ import WinampButton from "./WinampButton";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
-  onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void;
 }
 
 // Winamp has a strange behavior for the buttons at the top of the main window.
@@ -15,17 +15,17 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 // for examples of this functionality in use.
 function ClickedDiv(props: Props) {
   const [clicked, setClicked] = useState(false);
-  function handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     setClicked(true);
-    if (props.onMouseDown) {
-      props.onMouseDown(e);
+    if (props.onPointerDown) {
+      props.onPointerDown(e);
     }
   }
   return (
     <WinampButton
       {...props}
       className={classnames(props.className, { clicked })}
-      onMouseDown={handleMouseDown}
+      onPointerDown={handlePointerDown}
     />
   );
 }

--- a/packages/webamp/js/components/EqualizerWindow/Band.tsx
+++ b/packages/webamp/js/components/EqualizerWindow/Band.tsx
@@ -10,6 +10,7 @@ interface Props {
   id: string;
   band: SliderType;
   onChange(value: number): void;
+  clickOriginatedInEq?: boolean;
 }
 
 const MAX_VALUE = 100;
@@ -32,7 +33,7 @@ const Handle = () => {
   return <div style={style} className="slider-handle" />;
 };
 
-export default function Band({ id, onChange, band }: Props) {
+export default function Band({ id, onChange, band, clickOriginatedInEq }: Props) {
   const sliders = useTypedSelector(Selectors.getSliders);
   const value = sliders[band];
   const backgroundPosition = useMemo(() => {
@@ -51,7 +52,7 @@ export default function Band({ id, onChange, band }: Props) {
       id={id}
       className="band"
       style={{ backgroundPosition, height: 63 }}
-      requireClicksOriginateLocally={false}
+      requireClicksOriginateLocally={!(band !== 'preamp' && clickOriginatedInEq)}
     >
       <VerticalSlider
         height={62}
@@ -61,7 +62,7 @@ export default function Band({ id, onChange, band }: Props) {
         onBeforeChange={() => focusBand(band)}
         onChange={(val) => onChange((1 - val) * MAX_VALUE)}
         onAfterChange={unsetFocus}
-        requireClicksOriginateLocally={false}
+        requireClicksOriginateLocally={!(band !== 'preamp' && clickOriginatedInEq)}
         handle={<Handle />}
       />
     </WinampButton>

--- a/packages/webamp/js/components/EqualizerWindow/Band.tsx
+++ b/packages/webamp/js/components/EqualizerWindow/Band.tsx
@@ -42,7 +42,7 @@ export default function Band({ id, onChange, band }: Props) {
     return `-${xOffset}px -${yOffset}px`;
   }, [value]);
   const focusBand = useActionCreator(Actions.focusBand);
-  const usetFocus = useActionCreator(Actions.unsetFocus);
+  const unsetFocus = useActionCreator(Actions.unsetFocus);
 
   // Note: The band background is actually one pixel taller (63) than the slider
   // it contains (62).
@@ -51,6 +51,7 @@ export default function Band({ id, onChange, band }: Props) {
       id={id}
       className="band"
       style={{ backgroundPosition, height: 63 }}
+      requireClicksOriginateLocally={false}
     >
       <VerticalSlider
         height={62}
@@ -59,7 +60,8 @@ export default function Band({ id, onChange, band }: Props) {
         value={1 - value / MAX_VALUE}
         onBeforeChange={() => focusBand(band)}
         onChange={(val) => onChange((1 - val) * MAX_VALUE)}
-        onAfterChange={usetFocus}
+        onAfterChange={unsetFocus}
+        requireClicksOriginateLocally={false}
         handle={<Handle />}
       />
     </WinampButton>

--- a/packages/webamp/js/components/EqualizerWindow/index.tsx
+++ b/packages/webamp/js/components/EqualizerWindow/index.tsx
@@ -46,7 +46,7 @@ const EqualizerWindow = () => {
 
   // Track whether the click originated in the "hertz" area of the EQ
   // We only want to allow drag across the EQ when the click originated in that area
-  const [clickOriginatedInEq, setClickOriginatedInEq] = useState(false);
+  const [clickOriginatedInEq, setClickOriginatedInEq] = useState(true);
 
   const onPointerDownEq = (e: React.PointerEvent<HTMLDivElement>) => {
     e.stopPropagation();

--- a/packages/webamp/js/components/EqualizerWindow/index.tsx
+++ b/packages/webamp/js/components/EqualizerWindow/index.tsx
@@ -47,17 +47,19 @@ const EqualizerWindow = () => {
   // Track whether the click originated in the "hertz" area of the EQ
   // We only want to allow drag across the EQ when the click originated in that area
   const [clickOriginatedInEq, setClickOriginatedInEq] = useState(false);
-  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+
+  const onPointerDownEq = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    setClickOriginatedInEq(false);
+  };
+
+  const onPointerDownHz = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.stopPropagation(); // To prevent onPointerDownEq from firing
     setClickOriginatedInEq(true);
-    function onRelease(ee: PointerEvent) {
-      setClickOriginatedInEq(false);
-      document.getElementById('hertzarea')?.removeEventListener("pointerup", onRelease);
-    }
-    document.getElementById('hertzarea')?.addEventListener("pointerup", onRelease);
   };
 
   return (
-    <div id="equalizer-window" className={className}>
+    <div id="equalizer-window" className={className} onPointerDown={onPointerDownEq}>
       <FocusTarget windowId={WINDOWS.EQUALIZER}>
         {shade ? (
           <EqualizerShade />
@@ -77,7 +79,7 @@ const EqualizerWindow = () => {
             <div id="plus12db" onClick={setEqToMax} />
             <div id="zerodb" onClick={setEqToMid} />
             <div id="minus12db" onClick={setEqToMin} />
-            <div id="hertzarea" onPointerDown={onPointerDown}>
+            <div onPointerDown={onPointerDownHz}>
               {BANDS.map((hertz) => (
                 <Band
                   key={hertz}

--- a/packages/webamp/js/components/EqualizerWindow/index.tsx
+++ b/packages/webamp/js/components/EqualizerWindow/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import classnames from "classnames";
 
 import { BANDS, WINDOWS } from "../../constants";
@@ -42,6 +43,19 @@ const EqualizerWindow = () => {
     window: true,
     draggable: true,
   });
+
+  // Track whether the click originated in the "hertz" area of the EQ
+  // We only want to allow drag across the EQ when the click originated in that area
+  const [clickOriginatedInEq, setClickOriginatedInEq] = useState(false);
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    setClickOriginatedInEq(true);
+    function onRelease(ee: PointerEvent) {
+      setClickOriginatedInEq(false);
+      document.getElementById('hertzarea')?.removeEventListener("pointerup", onRelease);
+    }
+    document.getElementById('hertzarea')?.addEventListener("pointerup", onRelease);
+  };
+
   return (
     <div id="equalizer-window" className={className}>
       <FocusTarget windowId={WINDOWS.EQUALIZER}>
@@ -63,14 +77,17 @@ const EqualizerWindow = () => {
             <div id="plus12db" onClick={setEqToMax} />
             <div id="zerodb" onClick={setEqToMid} />
             <div id="minus12db" onClick={setEqToMin} />
-            {BANDS.map((hertz) => (
-              <Band
-                key={hertz}
-                id={bandClassName(hertz)}
-                band={hertz}
-                onChange={(value) => setHertzValue(hertz, value)}
-              />
-            ))}
+            <div id="hertzarea" onPointerDown={onPointerDown}>
+              {BANDS.map((hertz) => (
+                <Band
+                  key={hertz}
+                  id={bandClassName(hertz)}
+                  band={hertz}
+                  onChange={(value) => setHertzValue(hertz, value)}
+                  clickOriginatedInEq={clickOriginatedInEq}
+                />
+              ))}
+            </div>
           </div>
         )}
       </FocusTarget>

--- a/packages/webamp/js/components/MainWindow/Shade.tsx
+++ b/packages/webamp/js/components/MainWindow/Shade.tsx
@@ -9,7 +9,7 @@ const Shade = memo(() => {
   return (
     <ClickedDiv
       id="shade"
-      onMouseDown={handleClick}
+      onPointerDown={handleClick}
       onDoubleClick={(e) => e.stopPropagation()}
       title="Toggle Windowshade Mode"
     />

--- a/packages/webamp/js/components/VerticalSlider.tsx
+++ b/packages/webamp/js/components/VerticalSlider.tsx
@@ -31,7 +31,7 @@ export default function VerticalSlider({
   onBeforeChange,
   onChange,
   onAfterChange,
-  requireClicksOriginateLocally,
+  requireClicksOriginateLocally = true,
   disabled,
 }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -123,7 +123,3 @@ export default function VerticalSlider({
     </div>
   );
 }
-
-VerticalSlider.defaultProps = {
-  requireClicksOriginateLocally: true
-};

--- a/packages/webamp/js/components/VerticalSlider.tsx
+++ b/packages/webamp/js/components/VerticalSlider.tsx
@@ -10,12 +10,12 @@ type Props = {
   onBeforeChange?: () => void;
   onChange: (value: number) => void;
   onAfterChange?: () => void;
+  requireClicksOriginateLocally?: boolean;
   disabled?: boolean;
 };
 
 type RegOptions = {
   target: HTMLElement;
-  touch: boolean;
   clientY: number;
 };
 
@@ -31,12 +31,13 @@ export default function VerticalSlider({
   onBeforeChange,
   onChange,
   onAfterChange,
+  requireClicksOriginateLocally,
   disabled,
 }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<HTMLDivElement | null>(null);
 
-  function registerMoveListener({ target, clientY, touch }: RegOptions) {
+  function registerMoveListener({ target, clientY }: RegOptions) {
     const sliderNode = ref.current;
     const handleNode = handleRef.current;
     if (sliderNode == null || handleNode == null) {
@@ -70,39 +71,19 @@ export default function VerticalSlider({
       onChange(Utils.clamp(startOffset / spanSize, 0, 1));
     }
 
-    if (touch) {
-      const handleTouchMove = (event: TouchEvent) => {
-        if (event.cancelable) {
-          event.preventDefault();
-        }
-        moveToPosition(event.touches[0].clientY);
-      };
-      const handleTouchEnd = () => {
-        if (onAfterChange != null) {
-          onAfterChange();
-        }
-        document.removeEventListener("touchmove", handleTouchMove);
-        document.removeEventListener("touchend", handleTouchEnd);
-      };
-      document.addEventListener("touchmove", handleTouchMove, {
-        passive: false,
-      });
-      document.addEventListener("touchend", handleTouchEnd);
-    } else {
-      const handleMouseMove = (event: MouseEvent) => {
-        event.preventDefault();
-        moveToPosition(event.clientY);
-      };
-      const handleMouseUp = () => {
-        if (onAfterChange != null) {
-          onAfterChange();
-        }
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
-      };
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
-    }
+    const handlePointerMove = (event: PointerEvent) => {
+      event.preventDefault();
+      moveToPosition(event.clientY);
+    };
+    const handleRelease = () => {
+      if (onAfterChange != null) {
+        onAfterChange();
+      }
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handleRelease);
+    };
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", handleRelease);
 
     if (onBeforeChange != null) {
       onBeforeChange();
@@ -112,29 +93,28 @@ export default function VerticalSlider({
     moveToPosition(clientY);
   }
 
-  function handleMouseDown(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+  function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     e.preventDefault();
     registerMoveListener({
       target: e.target as HTMLElement,
       clientY: e.clientY,
-      touch: false,
     });
   }
 
-  function handleTouchStart(e: React.TouchEvent<HTMLDivElement>) {
-    registerMoveListener({
-      target: e.target as HTMLElement,
-      clientY: e.touches[0].clientY,
-      touch: true,
-    });
+  // We watch for events onPointerEnter only when requireClicksOriginateLocally === false
+  // If the mouse/touch enters the Slider area, and the button/touch is already down, trigger a PointerDown
+  function handlePointerEnter(e: React.PointerEvent<HTMLDivElement>) {
+    if (e.buttons === 1) {
+      handlePointerDown(e);
+    }
   }
-
+  
   const offset = Math.floor((height - handleHeight) * value);
   return (
     <div
       style={{ height, width }}
-      onMouseDown={disabled ? undefined : handleMouseDown}
-      onTouchStart={disabled ? undefined : handleTouchStart}
+      onPointerDown={disabled ? undefined : handlePointerDown}
+      onPointerEnter={disabled || requireClicksOriginateLocally ? undefined : handlePointerEnter}
       ref={ref}
     >
       <div style={{ transform: `translateY(${offset}px)` }} ref={handleRef}>
@@ -143,3 +123,7 @@ export default function VerticalSlider({
     </div>
   );
 }
+
+VerticalSlider.defaultProps = {
+  requireClicksOriginateLocally: true
+};

--- a/packages/webamp/js/components/WinampButton.tsx
+++ b/packages/webamp/js/components/WinampButton.tsx
@@ -32,8 +32,7 @@ type Props = DetailedHTMLPropsAndMore;
  */
 export default function WinampButton(props: Props): JSX.Element {
   const [active, setActive] = useState(false);
-  const originalOnPointerDown = props.onPointerDown;
-  const { requireClicksOriginateLocally } = props;
+  const { requireClicksOriginateLocally, onPointerDown: originalOnPointerDown } = props;
 
   const onPointerDown = useCallback(
     (e) => {

--- a/packages/webamp/js/components/WinampButton.tsx
+++ b/packages/webamp/js/components/WinampButton.tsx
@@ -32,7 +32,7 @@ type Props = DetailedHTMLPropsAndMore;
  */
 export default function WinampButton(props: Props): JSX.Element {
   const [active, setActive] = useState(false);
-  const { requireClicksOriginateLocally, onPointerDown: originalOnPointerDown } = props;
+  const { requireClicksOriginateLocally, onPointerDown: originalOnPointerDown, ...htmlProps } = props;
 
   const onPointerDown = useCallback(
     (e) => {
@@ -72,10 +72,6 @@ export default function WinampButton(props: Props): JSX.Element {
     }
   };
 
-  // Remove the custom prop "requireClicksOriginateLocally" before passing the HTML props to the child div
-  const htmlProps = {...props};
-  delete htmlProps.requireClicksOriginateLocally;
-  
   const className = classnames(props.className, { [ACTIVE_CLASSNAME]: active });
   return (
     <div

--- a/packages/webamp/js/components/WinampButton.tsx
+++ b/packages/webamp/js/components/WinampButton.tsx
@@ -9,7 +9,11 @@ import {
 const ACTIVE_CLASSNAME = "winamp-active";
 const LEFT_MOUSE_NUMBER = 0;
 
-type Props = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+interface DetailedHTMLPropsAndMore extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  requireClicksOriginateLocally?: boolean;
+}
+
+type Props = DetailedHTMLPropsAndMore;
 
 /**
  * Renders a `div` with an `.winamp-active` class if the element is being clicked/tapped.
@@ -28,56 +32,62 @@ type Props = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
  */
 export default function WinampButton(props: Props): JSX.Element {
   const [active, setActive] = useState(false);
-  const originalOnMouseDown = props.onMouseDown;
+  const originalOnPointerDown = props.onPointerDown;
+  const { requireClicksOriginateLocally } = props;
 
-  const onMouseDown = useCallback(
+  const onPointerDown = useCallback(
     (e) => {
-      if (originalOnMouseDown != null) {
-        originalOnMouseDown(e);
+      if (originalOnPointerDown != null) {
+        originalOnPointerDown(e);
+      }
+      // Release the pointer capture
+      // https://w3c.github.io/pointerevents/#implicit-pointer-capture
+      // https://w3c.github.io/pointerevents/#pointer-capture
+      if (!requireClicksOriginateLocally) {
+        e.target.releasePointerCapture(e.pointerId);
       }
       // We only care about left mouse.
-      if (e.nativeEvent.button !== LEFT_MOUSE_NUMBER) {
+      // -1 button comes on onPointerEnter so we allow that.
+      if (e.nativeEvent.button !== -1 && e.nativeEvent.button !== LEFT_MOUSE_NUMBER) {
         return;
       }
       setActive(true);
 
-      function onUp(ee: MouseEvent) {
-        if (ee.button !== LEFT_MOUSE_NUMBER) {
-          return;
-        }
+      function onRelease(ee: PointerEvent) {
         setActive(false);
-        document.removeEventListener("mouseup", onUp);
+        document.removeEventListener("pointerup", onRelease);
       }
-      document.addEventListener("mouseup", onUp);
+      document.addEventListener("pointerup", onRelease);
     },
-    [originalOnMouseDown]
+    [originalOnPointerDown]
   );
 
-  const originalOnTouchStart = props.onTouchStart;
+  // We watch for events onPointerEnter only when requireClicksOriginateLocally === false
+  // If the pointer enters the WinampButton area, and the pointer button is already down, trigger a PointerDown
+  const onPointerEnter = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.buttons === 1) {
+      // Emit a pointerup to get the other buttons to release
+      document.dispatchEvent(new Event('pointerup', e));
+      // Simulate a pointerdown on the current button
+      onPointerDown(e);
+    }
+  };
 
-  const onTouchStart = useCallback(
-    (e) => {
-      if (originalOnTouchStart != null) {
-        originalOnTouchStart(e);
-      }
-      setActive(true);
-
-      function onUp() {
-        setActive(false);
-        document.removeEventListener("touchend", onUp);
-      }
-      document.addEventListener("touchend", onUp);
-    },
-    [originalOnTouchStart]
-  );
-
+  // Remove the custom prop "requireClicksOriginateLocally" before passing the HTML props to the child div
+  const htmlProps = {...props};
+  delete htmlProps.requireClicksOriginateLocally;
+  
   const className = classnames(props.className, { [ACTIVE_CLASSNAME]: active });
   return (
     <div
-      {...props}
+      {...htmlProps}
       className={className}
-      onMouseDown={onMouseDown}
-      onTouchStart={onTouchStart}
+      onPointerDown={onPointerDown}
+      onPointerEnter={requireClicksOriginateLocally ? undefined : onPointerEnter}
     />
   );
 }
+
+WinampButton.defaultProps = {
+  requireClicksOriginateLocally: true
+};

--- a/packages/webamp/js/components/WinampButton.tsx
+++ b/packages/webamp/js/components/WinampButton.tsx
@@ -65,8 +65,11 @@ export default function WinampButton(props: Props): JSX.Element {
   // If the pointer enters the WinampButton area, and the pointer button is already down, trigger a PointerDown
   const onPointerEnter = (e: React.PointerEvent<HTMLDivElement>) => {
     if (e.buttons === 1) {
-      // Emit a pointerup to get the other buttons to release
-      document.dispatchEvent(new Event('pointerup', e));
+      // Emit a CustomEvent pointerup to get the other buttons to release.
+      // Add a special -42 detail value so we can identify this event elsewhere and ignore if needed.
+      document.dispatchEvent(new CustomEvent('pointerup', {
+        detail: -42
+      }));
       // Simulate a pointerdown on the current button
       onPointerDown(e);
     }

--- a/packages/webamp/js/skinSelectors.ts
+++ b/packages/webamp/js/skinSelectors.ts
@@ -156,7 +156,7 @@ export const imageSelectors: Selectors = {
   EQ_TITLE_BAR_SELECTED: [".selected .equalizer-top"],
   EQ_SLIDER_BACKGROUND: [".band"],
   EQ_SLIDER_THUMB: [".band .slider-handle"],
-  // But the "active" pseudo selector on the parent, since clicking
+  // Put the "active" pseudo selector on the parent, since clicking
   // anywhere on the track moves the slider.
   EQ_SLIDER_THUMB_SELECTED: [".band.winamp-active .slider-handle"],
   EQ_ON_BUTTON: ["#on"],


### PR DESCRIPTION
In WinAMP you could mouse down on the first EQ VerticalSlider and drag the mouse across all of the VerticalSliders to set them all in one swipe. This PR brings the same capability to WebAMP.

https://user-images.githubusercontent.com/1002638/177918378-2615b514-f093-417a-85aa-0ad902d3c3e0.mov
