### PR TITLE
Add a default value for w.size in getWPixelSize

### DIFF
--- a/packages/webamp/js/selectors.ts
+++ b/packages/webamp/js/selectors.ts
@@ -430,7 +430,7 @@ const WINDOW_HEIGHT = 116;
 const SHADE_WINDOW_HEIGHT = 14;
 
 function getWPixelSize(w: WebampWindow, doubled: boolean) {
-  const [width, height] = w.size;
+  const [width, height] = w.size ? w.size : [0,0];
   const doubledMultiplier = doubled && w.canDouble ? 2 : 1;
   const pix = {
     height: WINDOW_HEIGHT + height * WINDOW_RESIZE_SEGMENT_HEIGHT,


### PR DESCRIPTION
getWPixelSize throws the error "Uncaught (in promise) TypeError: e.size is undefined" upon Webamp initialization if the config option 'windowLayout' is used but doesn't specify all windows, or lacks a 'size' property on some windows.

So for example, either of these windowLayout values will trigger the issue:

```
// equalizer not specified
windowLayout: {
	main: { position: { left: 0, top: 0 } },
	playlist: {
	  position: { left: 0, top: 232 },
	  size: { extraHeight: 4, extraWidth: 0 },
	}
}

// playlist lacks 'size'
windowLayout: {
	main: { position: { left: 0, top: 0 } },
	equalizer: { position: { left: 0, top: 116 } },
	playlist: {
	  position: { left: 0, top: 232 }
	}
}
```

My solution was to default 'size' to [0,0] if not present, which seems to work fine (error is resolved and windows render as expected), but not sure if this would be your preferred fix.  The problem windows are designated 'open: false' so that might be checked somewhere, alternatively.