### PR TITLE
Don't allow evaling JS in Milkdrop preset files

### DIFF
--- a/packages/webamp/js/components/MilkdropWindow/Visualizer.tsx
+++ b/packages/webamp/js/components/MilkdropWindow/Visualizer.tsx
@@ -59,6 +59,10 @@ function Visualizer({ analyser, width, height }: Props) {
         meshWidth: 32,
         meshHeight: 24,
         pixelRatio: window.devicePixelRatio || 1,
+        // Webamp may support rendering Milkdrop presets from untrusted sources.
+        // By using `onlyUseWASM` here we instruct Butterchurn not to `eval`
+        // JavaScript code included in older Butterchurn preset `.json` files.
+        onlyUseWASM: true,
       }
     );
     _visualizer.connectAudio(analyser);

--- a/packages/webamp/js/components/MilkdropWindow/Visualizer.tsx
+++ b/packages/webamp/js/components/MilkdropWindow/Visualizer.tsx
@@ -62,6 +62,7 @@ function Visualizer({ analyser, width, height }: Props) {
         // Webamp may support rendering Milkdrop presets from untrusted sources.
         // By using `onlyUseWASM` here we instruct Butterchurn not to `eval`
         // JavaScript code included in older Butterchurn preset `.json` files.
+        // https://jordaneldredge.com/blog/speeding-up-winamps-music-visualizer-with-webassembly/#security
         onlyUseWASM: true,
       }
     );


### PR DESCRIPTION
My [primary motivation](https://jordaneldredge.com/blog/speeding-up-winamps-music-visualizer-with-webassembly/#security) for working on `eel-wasm` over four years ago was to allow us to execute user-defined Milkdrop presets (e.g. via the URL) without exposing us to potential [XSS attacks](https://owasp.org/www-community/attacks/xss/). With this hole filed, we could start to allow users to load sensitive data in webamp.org. For example, we could re-enable our Dropbox integration.

However, I never go around to actually preventing old-style preset files from working, and only allowing the newer kind which can be compiled to Wasm on the fly.

This PR enables that enforcement.
