### PR TITLE
Add missing BLUESKY env vars to test setup

### DIFF
--- a/packages/skin-database/jest-setup.js
+++ b/packages/skin-database/jest-setup.js
@@ -31,3 +31,5 @@ process.env.INSTAGRAM_ACCESS_TOKEN = "<DUMMY>";
 process.env.INSTAGRAM_ACCOUNT_ID = "<DUMMY>";
 process.env.MASTODON_ACCESS_TOKEN = "<DUMMY>";
 process.env.SECRET = "<DUMMY>";
+process.env.BLUESKY_PASSWORD = "<DUMMY>";
+process.env.BLUESKY_USERNAME = "<DUMMY>";


### PR DESCRIPTION
## Summary
The skin-database tests were failing in CI because `BLUESKY_PASSWORD` and `BLUESKY_USERNAME` environment variables were added to `config.ts` but not to the `jest-setup.js` file that provides dummy values for tests.

## Changes
- Added `BLUESKY_PASSWORD` and `BLUESKY_USERNAME` dummy values to `jest-setup.js`

## Testing
- Verified all skin-database tests pass locally