### PR TITLE
Fix webamp-modern build outputs in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,7 @@
       "outputs": []
     },
     "webamp-modern#build": {
-      "outputs": []
+      "outputs": ["build/**"]
     },
     "webamp-modern#test": {
       "outputs": []


### PR DESCRIPTION
## Summary
The Compressed Size CI workflow was failing because the `webamp-modern#build` task had `outputs` set to an empty array in `turbo.json`. This meant turbo wouldn't cache or restore the build directory, causing the `mv` command in the deploy script to fail when it couldn't find the build directory on cache hits.

## Changes
- Changed `webamp-modern#build` outputs from `[]` to `["build/**"]` to properly cache and restore the build output.

## Testing
- Verified locally that the deploy script works correctly both on fresh builds and on cache hits (FULL TURBO mode).