### PR TITLE
Add skin-museum-og lint to CI

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -65,6 +65,7 @@
       "dependsOn": ["ani-cursor#build", "winamp-eqf#build"]
     },
     "skin-database#lint": {},
+    "skin-museum-og#lint": {},
     "webamp-modern#lint": {},
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
The `skin-museum-og` package has a lint script (`next lint`) but it was not included in `turbo.json`, so it wasn't being checked in CI.

## Changes
- Added `skin-museum-og#lint` task to `turbo.json` so it will be linted along with the other packages when `npx turbo lint` runs.

## Testing
- Verified locally that `npx turbo lint --filter=skin-museum-og` runs successfully with no errors.