### PR TITLE
Add ESLint to winamp-eqf and include in CI

### DIFF
--- a/packages/winamp-eqf/package.json
+++ b/packages/winamp-eqf/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
+    "lint": "eslint src --ext ts,js",
     "test": "jest",
     "type-check": "tsc --noEmit"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -66,6 +66,7 @@
     },
     "skin-database#lint": {},
     "webamp-modern#lint": {},
+    "winamp-eqf#lint": {},
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary
The `winamp-eqf` package had no lint script and wasn't being linted in CI.

## Changes
- Added `lint` script to `winamp-eqf/package.json`: `eslint src --ext ts,js`
- Added `winamp-eqf#lint` task to `turbo.json` so it runs alongside other packages during CI

## Testing
- Verified locally that `pnpm run lint` passes with no errors
- Confirmed the lint rules work by intentionally introducing a formatting error and seeing it caught by `prettier/prettier` rule