### PR TITLE
Add ESLint to ani-cursor and include in CI

### DIFF
--- a/packages/ani-cursor/package.json
+++ b/packages/ani-cursor/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "build": "tsc",
     "type-check": "tsc --noEmit",
+    "lint": "eslint src --ext ts,js",
     "test": "jest",
     "prepublish": "tsc"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -64,6 +64,7 @@
     "webamp#lint": {
       "dependsOn": ["ani-cursor#build", "winamp-eqf#build"]
     },
+    "ani-cursor#lint": {},
     "skin-database#lint": {},
     "webamp-modern#lint": {},
     "dev": {


### PR DESCRIPTION
## Summary
The `ani-cursor` package had no lint script and wasn't being linted in CI.

## Changes
- Added `lint` script to `ani-cursor/package.json`: `eslint src --ext ts,js`
- Added `ani-cursor#lint` task to `turbo.json` so it runs alongside other packages during CI

## Testing
- Verified locally that `pnpm run lint` passes with no errors
- Confirmed the lint rules work by intentionally introducing a formatting error and seeing it caught by `prettier/prettier` rule