### PR TITLE
Enable more lint rules for skin-database

### DIFF
--- a/packages/skin-database/.eslintrc.js
+++ b/packages/skin-database/.eslintrc.js
@@ -10,19 +10,8 @@ module.exports = {
     "@typescript-eslint/no-namespace": "off",
     // Override the base no-shadow rule since it conflicts with TypeScript
     "no-shadow": "off",
-    // Relax rules for this project's existing style
+    // camelcase has too many violations (333) to fix now
     camelcase: "off",
-    "dot-notation": "off",
-    eqeqeq: "off",
-    "no-undef-init": "off",
-    "no-return-await": "off",
-    "prefer-arrow-callback": "off",
-    "no-div-regex": "off",
-    "guard-for-in": "off",
-    "prefer-template": "off",
-    "no-else-return": "off",
-    "prefer-const": "off",
-    "new-cap": "off",
   },
   ignorePatterns: ["dist/**"],
 };

--- a/packages/skin-database/api/graphql/index.ts
+++ b/packages/skin-database/api/graphql/index.ts
@@ -13,6 +13,7 @@ export function getUserContext(ctx: Ctx): UserContext {
   return ctx.ctx;
 }
 
+// eslint-disable-next-line new-cap -- Express Router uses this pattern
 const router = Router();
 
 const yoga = createYoga({

--- a/packages/skin-database/api/graphql/resolvers/ClassicSkinResolver.ts
+++ b/packages/skin-database/api/graphql/resolvers/ClassicSkinResolver.ts
@@ -26,7 +26,7 @@ export default class ClassicSkinResolver implements NodeResolver, ISkin {
   async filename(normalize_extension?: boolean): Promise<string> {
     const filename = await this._model.getFileName();
     if (normalize_extension) {
-      return path.parse(filename).name + ".wsz";
+      return `${path.parse(filename).name}.wsz`;
     }
     return filename;
   }

--- a/packages/skin-database/api/graphql/resolvers/ModernSkinResolver.ts
+++ b/packages/skin-database/api/graphql/resolvers/ModernSkinResolver.ts
@@ -25,7 +25,7 @@ export default class ModernSkinResolver implements NodeResolver, ISkin {
   async filename(normalize_extension: boolean): Promise<string> {
     const filename = await this._model.getFileName();
     if (normalize_extension) {
-      return path.parse(filename).name + ".wal";
+      return `${path.parse(filename).name}.wal`;
     }
     return filename;
   }

--- a/packages/skin-database/api/graphql/resolvers/SkinResolver.ts
+++ b/packages/skin-database/api/graphql/resolvers/SkinResolver.ts
@@ -21,9 +21,8 @@ export default class SkinResolver {
   static fromModel(model: SkinModel): ISkin {
     if (model.getSkinType() === "MODERN") {
       return new ModernSkinResolver(model);
-    } else {
-      return new ClassicSkinResolver(model);
     }
+    return new ClassicSkinResolver(model);
   }
 }
 

--- a/packages/skin-database/app/(modern)/scroll/getClientSkins.ts
+++ b/packages/skin-database/app/(modern)/scroll/getClientSkins.ts
@@ -13,7 +13,7 @@ export async function getClientSkins(sessionId: string): Promise<ClientSkin[]> {
 
   const page = await getScrollPage(sessionId);
 
-  return await Promise.all(
+  return Promise.all(
     page.map(async (item) => {
       return getSkinForSession(ctx, sessionId, item.md5);
     })

--- a/packages/skin-database/app/(modern)/scroll/useScrollHint.ts
+++ b/packages/skin-database/app/(modern)/scroll/useScrollHint.ts
@@ -52,9 +52,8 @@ export function useScrollHint({
             return n1 * (t -= 1.5 / d1) * t + 0.75;
           } else if (t < 2.5 / d1) {
             return n1 * (t -= 2.25 / d1) * t + 0.9375;
-          } else {
-            return n1 * (t -= 2.625 / d1) * t + 0.984375;
           }
+          return n1 * (t -= 2.625 / d1) * t + 0.984375;
         };
 
         // Create a bounce effect: scroll down quickly, then bounce back

--- a/packages/skin-database/data/KeyValue.ts
+++ b/packages/skin-database/data/KeyValue.ts
@@ -15,10 +15,9 @@ export default class KeyValue {
       .count({ count: "*" })
       .first()) as { count: number };
     if (count) {
-      return await KeyValue.update(key, value);
-    } else {
-      return await KeyValue.insert(key, value);
+      return KeyValue.update(key, value);
     }
+    return KeyValue.insert(key, value);
   }
 
   static async update(key: string, value: any): Promise<void> {

--- a/packages/skin-database/data/SkinModel.ts
+++ b/packages/skin-database/data/SkinModel.ts
@@ -242,23 +242,22 @@ export default class SkinModel {
         this.getMd5() + ext
       );
       return fs.readFile(skinPath);
-    } else {
-      const response = await fetch(this.getSkinUrl());
-      if (!response.ok) {
-        const missingModernSkins =
-          (await KeyValue.get<string[]>("missingModernSkins")) ?? [];
-        const missingModernSkinsSet = new Set(missingModernSkins);
-        missingModernSkinsSet.add(this.getMd5());
-        await KeyValue.set(
-          "missingModernSkins",
-          Array.from(missingModernSkinsSet)
-        );
-        throw new Error(
-          `Could not fetch skin at "${this.getSkinUrl()}" (Marked in missingModernSkins in the KeyValue store)`
-        );
-      }
-      return response.buffer();
     }
+    const response = await fetch(this.getSkinUrl());
+    if (!response.ok) {
+      const missingModernSkins =
+        (await KeyValue.get<string[]>("missingModernSkins")) ?? [];
+      const missingModernSkinsSet = new Set(missingModernSkins);
+      missingModernSkinsSet.add(this.getMd5());
+      await KeyValue.set(
+        "missingModernSkins",
+        Array.from(missingModernSkinsSet)
+      );
+      throw new Error(
+        `Could not fetch skin at "${this.getSkinUrl()}" (Marked in missingModernSkins in the KeyValue store)`
+      );
+    }
+    return response.buffer();
   });
 
   getScreenshotBuffer = mem(async (): Promise<Buffer> => {
@@ -385,10 +384,9 @@ export default class SkinModel {
   }
 
   async hasGeneral(): Promise<boolean> {
-    return (
-      (await this._hasSpriteSheet("GEN")) &&
-      (await this._hasSpriteSheet("GENEX"))
-    );
+    const hasGen = await this._hasSpriteSheet("GEN");
+    const hasGenEx = await this._hasSpriteSheet("GENEX");
+    return hasGen && hasGenEx;
   }
 
   async getAlgoliaIndexUpdates(limit?: number): Promise<any[]> {

--- a/packages/skin-database/db.ts
+++ b/packages/skin-database/db.ts
@@ -2,4 +2,5 @@ import Knex from "knex";
 import * as knexConfigs from "./knexfile";
 import { NODE_ENV } from "./config";
 
+// eslint-disable-next-line new-cap -- Knex uses this pattern
 export const knex = Knex(knexConfigs[NODE_ENV ?? "test"]);

--- a/packages/skin-database/discord-bot/commands/debug.ts
+++ b/packages/skin-database/discord-bot/commands/debug.ts
@@ -20,7 +20,7 @@ async function handler(message: Message, args: [string]) {
   const jsonString = JSON.stringify(data, null, 2);
   for (let i = 0; i < jsonString.length; i += pageSize) {
     await message.channel.send(
-      "```" + jsonString.slice(i, i + pageSize) + "```"
+      `\`\`\`${jsonString.slice(i, i + pageSize)}\`\`\``
     );
   }
 }

--- a/packages/skin-database/legacy-client/src/Feedback.js
+++ b/packages/skin-database/legacy-client/src/Feedback.js
@@ -26,7 +26,7 @@ export default function Feedback() {
       alert("Please add a message before sending.");
       return;
     }
-    const body = { message, email, url: "https://skins.webamp.org" + url };
+    const body = { message, email, url: `https://skins.webamp.org${url}` };
     setSending(true);
     await sendFeedback(body);
 

--- a/packages/skin-database/legacy-client/src/ReviewPage.js
+++ b/packages/skin-database/legacy-client/src/ReviewPage.js
@@ -25,9 +25,8 @@ async function getSkinToReview() {
   const data = await Utils.fetchGraphql(mutation);
   if (data.me.username) {
     return data.skin_to_review;
-  } else {
-    window.location = `${API_URL}/auth`;
   }
+  window.location = `${API_URL}/auth`;
 }
 
 function useQueuedSkin() {

--- a/packages/skin-database/legacy-client/src/components/DownloadText.js
+++ b/packages/skin-database/legacy-client/src/components/DownloadText.js
@@ -3,7 +3,7 @@ import React, { useLayoutEffect, useState } from "react";
 function DownloadText({ text, children, ...restProps }) {
   const [url, setUrl] = useState(null);
   useLayoutEffect(() => {
-    let blob = new Blob([text], {
+    const blob = new Blob([text], {
       type: "text/plain;charset=utf-8",
     });
     const url = URL.createObjectURL(blob);

--- a/packages/skin-database/legacy-client/src/components/Skin.js
+++ b/packages/skin-database/legacy-client/src/components/Skin.js
@@ -31,9 +31,8 @@ function Skin({
           e.preventDefault();
           doesNotConcentToNsfw();
           return;
-        } else {
-          consentsToNsfw();
         }
+        consentsToNsfw();
       }
       if (Utils.eventIsLinkClick(e)) {
         e.preventDefault();

--- a/packages/skin-database/legacy-client/src/debug/DebugFile.js
+++ b/packages/skin-database/legacy-client/src/debug/DebugFile.js
@@ -30,7 +30,7 @@ export function PreviewFile({ file }) {
         (Hover in the box to see .cur preview)
         <div
           style={{
-            cursor: "url(" + file.url + "), auto",
+            cursor: `url(${file.url}), auto`,
             border: "2px solid black",
             minWidth: "400px",
             minHeight: "400px",

--- a/packages/skin-database/legacy-client/src/debug/DebugSkin.js
+++ b/packages/skin-database/legacy-client/src/debug/DebugSkin.js
@@ -52,7 +52,7 @@ export default function DebugSkin({ md5 }) {
   const skin = data.fetch_skin_by_md5;
 
   const screenshotFile = {
-    filename: skin.filename + ".png",
+    filename: `${skin.filename}.png`,
     url: skin.screenshot_url,
   };
   const focusedFile = file || screenshotFile;
@@ -199,5 +199,5 @@ function formatBytes(bytes, decimals = 2) {
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }

--- a/packages/skin-database/legacy-client/src/hashFile.js
+++ b/packages/skin-database/legacy-client/src/hashFile.js
@@ -1,7 +1,7 @@
 import SparkMD5 from "spark-md5";
 
 export function hashFile(file) {
-  let blobSlice =
+  const blobSlice =
     File.prototype.slice ||
     File.prototype.mozSlice ||
     File.prototype.webkitSlice;
@@ -26,7 +26,7 @@ export function hashFile(file) {
     fileReader.onerror = reject;
 
     function loadNext() {
-      let start = currentChunk * chunkSize,
+      const start = currentChunk * chunkSize,
         end = start + chunkSize >= file.size ? file.size : start + chunkSize;
 
       fileReader.readAsArrayBuffer(blobSlice.call(file, start, end));

--- a/packages/skin-database/legacy-client/src/hooks.js
+++ b/packages/skin-database/legacy-client/src/hooks.js
@@ -89,9 +89,8 @@ export function useWebampAnimation({ initialPosition }) {
         transitionBeginEvents.next(null);
       });
       return () => subscription.unsubscribe();
-    } else {
-      transitionBeginEvents.next(null);
     }
+    transitionBeginEvents.next(null);
   }, [initialPosition, setCentered, transitionBeginEvents]);
 
   const handleWebampLoaded = useCallback(() => {

--- a/packages/skin-database/legacy-client/src/redux/epics.js
+++ b/packages/skin-database/legacy-client/src/redux/epics.js
@@ -452,7 +452,7 @@ const urlEpic = (actions, state) => {
 
       // There are some params that we want to preserve across reloads.
       for (const key of ["rest", "vps"]) {
-        let current = currentParams.get(key);
+        const current = currentParams.get(key);
         if (current == null) {
           proposedUrl.searchParams.delete(key);
         } else {

--- a/packages/skin-database/legacy-client/src/upload/UploadGrid.js
+++ b/packages/skin-database/legacy-client/src/upload/UploadGrid.js
@@ -77,9 +77,8 @@ function Inner({ files }) {
             upload
           </>
         );
-      } else {
-        return `Thanks for your contribution!`;
       }
+      return `Thanks for your contribution!`;
     }
     return `No missing skins found`;
   };

--- a/packages/skin-database/legacy-client/src/utils.js
+++ b/packages/skin-database/legacy-client/src/utils.js
@@ -13,7 +13,7 @@ export function museumUrlFromHash(hash) {
 }
 
 export function getWindowSize() {
-  let w = window,
+  const w = window,
     d = document,
     e = d.documentElement,
     g = d.getElementsByTagName("body")[0],

--- a/packages/skin-database/migrations/20201119094845_remove_average_color.ts
+++ b/packages/skin-database/migrations/20201119094845_remove_average_color.ts
@@ -1,13 +1,13 @@
 import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
-  await knex.schema.table("skins", function (table) {
+  await knex.schema.table("skins", (table) => {
     table.dropColumn("average_color");
   });
 }
 
 export async function down(knex: Knex): Promise<any> {
-  await knex.schema.table("skins", function (table) {
+  await knex.schema.table("skins", (table) => {
     table.string("average_color");
   });
 }

--- a/packages/skin-database/migrations/20201130002421_reviewer_field.ts
+++ b/packages/skin-database/migrations/20201130002421_reviewer_field.ts
@@ -1,13 +1,13 @@
 import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
-  await knex.schema.table("skin_reviews", function (table) {
+  await knex.schema.table("skin_reviews", (table) => {
     table.text("reviewer");
   });
 }
 
 export async function down(knex: Knex): Promise<any> {
-  await knex.schema.table("skin_reviews", function (table) {
+  await knex.schema.table("skin_reviews", (table) => {
     table.dropColumn("reviewer");
   });
 }

--- a/packages/skin-database/migrations/20201202012156_remove_tweet_url.ts
+++ b/packages/skin-database/migrations/20201202012156_remove_tweet_url.ts
@@ -1,13 +1,13 @@
 import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
-  await knex.schema.table("tweets", function (table) {
+  await knex.schema.table("tweets", (table) => {
     table.dropColumn("url");
   });
 }
 
 export async function down(knex: Knex): Promise<any> {
-  await knex.schema.table("tweets", function (table) {
+  await knex.schema.table("tweets", (table) => {
     table.text("url");
   });
 }

--- a/packages/skin-database/migrations/20210105174314_add_archive_file_timestamp.ts
+++ b/packages/skin-database/migrations/20210105174314_add_archive_file_timestamp.ts
@@ -1,13 +1,13 @@
 import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
-  await knex.schema.table("archive_files", function (table) {
+  await knex.schema.table("archive_files", (table) => {
     table.timestamp("file_date");
   });
 }
 
 export async function down(knex: Knex): Promise<any> {
-  await knex.schema.table("archive_files", function (table) {
+  await knex.schema.table("archive_files", (table) => {
     table.dropColumn("file_date");
   });
 }

--- a/packages/skin-database/migrations/20210118140710_support_refresh.ts
+++ b/packages/skin-database/migrations/20210118140710_support_refresh.ts
@@ -1,7 +1,7 @@
 import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
-  await knex.schema.createTable("refreshes", function (table) {
+  await knex.schema.createTable("refreshes", (table) => {
     table.increments();
     table.string("skin_md5").notNullable();
     table.string("error");

--- a/packages/skin-database/regionParser.ts
+++ b/packages/skin-database/regionParser.ts
@@ -68,7 +68,7 @@ const parseIni = (text: string): IniData => {
       const value = match[2]
         // Ignore anything after a second `=`
         // TODO: What if this is inside quotes or escaped?
-        .replace(/=.*$/g, "")
+        .replace(/[=].*$/g, "")
         .trim()
         // Strip quotes
         // TODO: What about escaped quotes?

--- a/packages/skin-database/services/openAi.ts
+++ b/packages/skin-database/services/openAi.ts
@@ -2,7 +2,7 @@ import SkinModel from "../data/SkinModel.js";
 import OpenAI from "openai";
 
 const client = new OpenAI({
-  apiKey: process.env["OPENAI_API_KEY"], // This is the default and can be omitted
+  apiKey: process.env.OPENAI_API_KEY, // This is the default and can be omitted
 });
 
 const prompt2 = `You are a staff digital preservationist working at the Internet Archive.

--- a/packages/skin-database/skinHash.ts
+++ b/packages/skin-database/skinHash.ts
@@ -48,7 +48,7 @@ export async function getSkinFileData(
   skin: SkinModel
 ): Promise<(FileData | null)[]> {
   const zip = await skin.getZip();
-  return await Promise.all(Object.values(zip.files).map(getFileData));
+  return Promise.all(Object.values(zip.files).map(getFileData));
 }
 
 // https://stackoverflow.com/a/46700791/1263117

--- a/packages/skin-database/tasks/mastodon.ts
+++ b/packages/skin-database/tasks/mastodon.ts
@@ -68,7 +68,7 @@ async function post(md5: string): Promise<string> {
     }
   );
 
-  if (resp.statusCode != 200) {
+  if (resp.statusCode !== 200) {
     console.log(JSON.stringify(resp, null, 2));
     console.log("data", data);
     throw new Error(

--- a/packages/skin-database/tasks/scrapeLikes.ts
+++ b/packages/skin-database/tasks/scrapeLikes.ts
@@ -26,7 +26,7 @@ type TweetPayload = {
 };
 
 async function getTweets(twitterClient): Promise<TweetPayload[]> {
-  let max_id: string | undefined = undefined;
+  let max_id: string | undefined;
   let tweets: TweetPayload[] = [];
   let callCount = 0;
 

--- a/packages/skin-database/tasks/syncToArchive.ts
+++ b/packages/skin-database/tasks/syncToArchive.ts
@@ -59,7 +59,7 @@ export async function uploadScreenshotIfSafe(md5: string): Promise<boolean> {
     return false;
   }
   const skinFiles = iaItem.getSkinFiles();
-  if (skinFiles.length != 1) {
+  if (skinFiles.length !== 1) {
     console.warn(`Has ${skinFiles.length} skins`);
     return false;
   }

--- a/packages/skin-database/tasks/tweet.ts
+++ b/packages/skin-database/tasks/tweet.ts
@@ -33,12 +33,12 @@ export async function tweet(
       return;
     }
     const tweetStatus = await tweetableSkin.getTweetStatus();
-    if (tweetStatus == "TWEETED") {
+    if (tweetStatus === "TWEETED") {
       // @ts-ignore
       // await tweetBotChannel.send(`Oops! This skin has alraedy been tweeted.`);
       // return;
     }
-    if (tweetStatus == "REJECTED" || tweetStatus == "NSFW") {
+    if (tweetStatus === "REJECTED" || tweetStatus === "NSFW") {
       // @ts-ignore
       await tweetBotChannel.send(`Oops! Can't tweet a rejected skin.`);
       return;

--- a/packages/skin-database/tasks/tweetMilestones.ts
+++ b/packages/skin-database/tasks/tweetMilestones.ts
@@ -18,7 +18,7 @@ type TweetPayload = {
 };
 
 async function getTweets(twitterClient): Promise<TweetPayload[]> {
-  let max_id: string | undefined = undefined;
+  let max_id: string | undefined;
   let tweets: TweetPayload[] = [];
   let callCount = 0;
 


### PR DESCRIPTION
## Summary
This PR enables additional ESLint rules for the skin-database package that were previously disabled. Stacked on top of #1324.

## Rules Enabled
All root ESLint rules are now enabled except `camelcase` (which has 333 violations and would require major refactoring).

| Rule | Violations Fixed |
|------|-----------------|
| `eqeqeq` | 5 |
| `prefer-const` | 11 |
| `prefer-template` | 7 |
| `prefer-arrow-callback` | 9 |
| `no-else-return` | 8 |
| `no-return-await` | 5 |
| `no-undef-init` | 2 |
| `dot-notation` | 1 |
| `guard-for-in` | 0 |
| `no-div-regex` | 1 |
| `new-cap` | 2 |

## Testing
- All lint checks pass
- All tests pass