### PR TITLE
Use turbo lint for root lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:integration": "npx turbo run integration-tests",
     "test:all": "npx turbo run test integration-tests",
     "test:unit": "jest",
-    "lint": "eslint . --ext ts,tsx,js,jsx --rulesdir=packages/webamp-modern/tools/eslint-rules",
+    "lint": "npx turbo lint",
     "type-check": "pnpm --filter webamp type-check && pnpm --filter ani-cursor type-check && pnpm --filter skin-database type-check && pnpm --filter webamp-docs type-check && pnpm --filter winamp-eqf type-check",
     "deploy": "npx turbo webamp#build webamp-modern#build --concurrency 1 && mv packages/webamp-modern/build packages/webamp/dist/demo-site/modern",
     "format": "prettier --write '**/*.{js,ts,tsx}'"


### PR DESCRIPTION
This ensures `pnpm run lint` at the monorepo root runs the same lint tasks as CI (`npx turbo lint`), providing consistent behavior between local development and CI.

Previously, the root lint script ran ESLint directly on the entire workspace, while CI used Turborepo to run each package's individual lint script. This could lead to discrepancies between local and CI lint results.