### PR TITLE
Fix CI: TypeScript error in Webamp renderInto call

### DIFF
--- a/packages/skin-database/app/(modern)/scroll/Webamp.tsx
+++ b/packages/skin-database/app/(modern)/scroll/Webamp.tsx
@@ -42,7 +42,7 @@ export default function WebampComponent({
 
       webamp.onClose(closeModal);
       // ref.current!.style.opacity = "0";
-      await webamp.renderInto(ref.current);
+      await webamp.renderInto(ref.current!);
       const { width } = outerRef.current!.getBoundingClientRect();
       const zoom = width / SCREENSHOT_WIDTH;
       document


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error that was causing CI to fail
- Add non-null assertion operator to `ref.current` when calling `webamp.renderInto()`

## Root Cause
The new Webamp `renderInto` API expects a non-null `HTMLElement` parameter, but `ref.current` has type `HTMLDivElement | null`. The TypeScript compiler was correctly flagging this as a potential runtime error.

## Changes Made
- Updated `packages/skin-database/app/(modern)/scroll/Webamp.tsx` line 45
- Added non-null assertion operator (`!`) to match the pattern used elsewhere in the component (lines 46, 51)

## Test Plan
- [x] TypeScript compilation passes locally (`pnpm run type-check`)
- [x] Linting passes locally (`pnpm run lint`)  
- [x] Build completes successfully (`pnpm run build`)
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)