### PR TITLE
Remove unused RichText import to fix CI lint failure

### DIFF
--- a/packages/skin-database/tasks/bluesky.ts
+++ b/packages/skin-database/tasks/bluesky.ts
@@ -5,7 +5,6 @@ import {
   AppBskyRichtextFacet,
   AtpAgent,
   BlobRef,
-  RichText,
 } from "@atproto/api";
 import {
   TWEET_BOT_CHANNEL_ID,


### PR DESCRIPTION
## Summary

- Removes the unused `RichText` import from `packages/skin-database/tasks/bluesky.ts`
- The import was left behind after the Bluesky posting logic was refactored (commit 247bda11) to use manual facets instead of the `RichText` helper class
- ESLint's `no-unused-vars` rule was flagging this as an error, causing the CI lint step to fail

## Root Cause

The commit "Consolidate bluesky posts" (247bda11) refactored the Bluesky posting code to build rich text facets manually using `AppBskyRichtextFacet.Main[]` instead of using the `RichText` helper. The `RichText` import was not cleaned up at that point.

## Test Plan

- [x] `pnpm --filter skin-database lint` passes locally with no errors
- CI "Lint and type-check" step should now pass

Generated with [Claude Code](https://claude.com/claude-code)