### PR TITLE
Remove unused RichText import to fix CI

### DIFF
--- a/packages/skin-database/tasks/bluesky.ts
+++ b/packages/skin-database/tasks/bluesky.ts
@@ -5,7 +5,6 @@ import {
   AppBskyRichtextFacet,
   AtpAgent,
   BlobRef,
-  RichText,
 } from "@atproto/api";
 import {
   TWEET_BOT_CHANNEL_ID,


### PR DESCRIPTION
## Summary
- Remove unused `RichText` import from `packages/skin-database/tasks/bluesky.ts` that was causing a lint failure in CI

## Test plan
- [ ] CI lint step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)